### PR TITLE
New landing + investor site (a16z demo, invest/building/team, pitch deck)

### DIFF
--- a/public/deck-stage.js
+++ b/public/deck-stage.js
@@ -1,0 +1,1748 @@
+/**
+ * <deck-stage> — reusable web component for HTML decks.
+ *
+ * Handles:
+ *  (a) speaker notes — reads <script type="application/json" id="speaker-notes">
+ *      and posts {slideIndexChanged: N} to the parent window on nav.
+ *  (b) keyboard navigation — ←/→, PgUp/PgDn, Space, Home/End, number keys.
+ *  (c) press R to reset to slide 0 (with a tasteful keyboard hint).
+ *  (d) bottom-center overlay showing slide count + hints, fades out on idle.
+ *  (e) auto-scaling — inner canvas is a fixed design size (default 1920×1080)
+ *      scaled with `transform: scale()` to fit the viewport, letterboxed.
+ *      Set the `noscale` attribute to render at authored size (1:1) — the
+ *      PPTX exporter sets this so its DOM capture sees unscaled geometry.
+ *  (f) print — `@media print` lays every slide out as its own page at the
+ *      design size, so the browser's Print → Save as PDF produces a clean
+ *      one-page-per-slide PDF with no extra setup.
+ *  (g) thumbnail rail — resizable left-hand column of per-slide thumbnails
+ *      (static clones). Click to navigate; ↑/↓ with a thumbnail focused to
+ *      step between slides; drag to reorder; right-click for
+ *      Skip / Move up / Move down / Delete (opens a Cancel/Delete confirm
+ *      dialog). Drag the rail's right edge to resize; width persists to
+ *      localStorage. Skipped slides carry `data-deck-skip`, are dimmed in
+ *      the rail, omitted from prev/next navigation, and hidden at print.
+ *      The rail is suppressed in presenting mode, in the host's Preview
+ *      mode (ViewerMode='none'), on `noscale`, and via the `no-rail`
+ *      attribute. Rail mutations dispatch a `deckchange`
+ *      CustomEvent on the element: detail = {action, from, to, slide}.
+ *
+ * Slides are HIDDEN, not unmounted. Non-active slides stay in the DOM with
+ * `visibility: hidden` + `opacity: 0`, so their state (videos, iframes,
+ * form inputs, React trees) is preserved across navigation.
+ *
+ * Lifecycle event — the component dispatches a `slidechange` CustomEvent on
+ * itself whenever the active slide changes (including the initial mount).
+ * The event bubbles and composes out of shadow DOM, so you can listen on
+ * the <deck-stage> element or on document:
+ *
+ *   document.querySelector('deck-stage').addEventListener('slidechange', (e) => {
+ *     e.detail.index         // new 0-based index
+ *     e.detail.previousIndex // previous index, or -1 on init
+ *     e.detail.total         // total slide count
+ *     e.detail.slide         // the new active slide element
+ *     e.detail.previousSlide // the prior slide element, or null on init
+ *     e.detail.reason        // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+ *   });
+ *
+ * Persistence: none at the deck level. The host app keeps the current slide
+ * in its own URL (?slide=) and re-delivers it via location.hash on load, so a
+ * bare load with no hash always starts at slide 1.
+ *
+ * Usage:
+ *   <style>deck-stage:not(:defined){visibility:hidden}</style>
+ *   <deck-stage width="1920" height="1080">
+ *     <section data-label="Title">...</section>
+ *     <section data-label="Agenda">...</section>
+ *   </deck-stage>
+ *   <script src="deck-stage.js"></script>
+ *
+ * The :not(:defined) rule prevents a flash of the first slide at its
+ * authored styles before this script runs and attaches the shadow root.
+ *
+ * Slides are the direct element children of <deck-stage>. Each slide is
+ * automatically tagged with:
+ *   - data-screen-label="NN Label"   (1-indexed, for comment flow)
+ *   - data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text"
+ */
+
+(() => {
+  const DESIGN_W_DEFAULT = 1920;
+  const DESIGN_H_DEFAULT = 1080;
+  const OVERLAY_HIDE_MS = 1800;
+  const VALIDATE_ATTR = 'no_overflowing_text,no_overlapping_text,slide_sized_text';
+
+  const pad2 = (n) => String(n).padStart(2, '0');
+
+  // Label precedence: data-label → data-screen-label (number stripped) → first heading → "Slide".
+  const getSlideLabel = (el) => {
+    const explicit = el.getAttribute('data-label');
+    if (explicit) return explicit;
+
+    const existing = el.getAttribute('data-screen-label');
+    if (existing) return existing.replace(/^\s*\d+\s*/, '').trim() || existing;
+
+    const h = el.querySelector('h1, h2, h3, [data-title]');
+    const t = h && (h.textContent || '').trim().slice(0, 40);
+    if (t) return t;
+
+    return 'Slide';
+  };
+
+  const stylesheet = `
+    :host {
+      position: fixed;
+      inset: 0;
+      display: block;
+      background: #000;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      overflow: hidden;
+    }
+    /* connectedCallback holds this until document.fonts.ready (capped 2s) so
+     * the first visible paint has the deck's real typography + final rail
+     * layout. opacity (not visibility) so the active slide can't un-hide
+     * itself via the ::slotted([data-deck-active]) visibility:visible rule.
+     * Only the stage/rail hide — the black :host background stays, so the
+     * iframe doesn't flash the page's default white. */
+    :host([data-fonts-pending]) .stage,
+    :host([data-fonts-pending]) .rail { opacity: 0; pointer-events: none; }
+
+    .stage {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .canvas {
+      position: relative;
+      transform-origin: center center;
+      flex-shrink: 0;
+      background: #fff;
+      will-change: transform;
+    }
+
+    /* Slides live in light DOM (via <slot>) so authored CSS still applies.
+       We absolutely position each slotted child to stack them. */
+    ::slotted(*) {
+      position: absolute !important;
+      inset: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      box-sizing: border-box !important;
+      overflow: hidden;
+      opacity: 0;
+      pointer-events: none;
+      visibility: hidden;
+    }
+    ::slotted([data-deck-active]) {
+      opacity: 1;
+      pointer-events: auto;
+      visibility: visible;
+    }
+
+    /* Tap zones for mobile — back/forward thirds like Stories.
+       Transparent, no visible UI, don't block the overlay. */
+    .tapzones {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      z-index: 2147482000;
+      pointer-events: none;
+    }
+    .tapzone {
+      flex: 1;
+      pointer-events: auto;
+      -webkit-tap-highlight-color: transparent;
+    }
+    /* Only activate tap zones on coarse pointers (touch devices). */
+    @media (hover: hover) and (pointer: fine) {
+      .tapzones { display: none; }
+    }
+
+    .overlay {
+      position: fixed;
+      left: 50%;
+      bottom: 22px;
+      transform: translate(-50%, 6px) scale(0.92);
+      filter: blur(6px);
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px;
+      background: #000;
+      color: #fff;
+      border-radius: 999px;
+      font-size: 12px;
+      font-feature-settings: "tnum" 1;
+      letter-spacing: 0.01em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 260ms ease, transform 260ms cubic-bezier(.2,.8,.2,1), filter 260ms ease;
+      transform-origin: center bottom;
+      z-index: 2147483000;
+      user-select: none;
+    }
+    .overlay[data-visible] {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translate(-50%, 0) scale(1);
+      filter: blur(0);
+    }
+
+    .btn {
+      appearance: none;
+      -webkit-appearance: none;
+      background: transparent;
+      border: 0;
+      margin: 0;
+      padding: 0;
+      color: inherit;
+      font: inherit;
+      cursor: default;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 28px;
+      min-width: 28px;
+      border-radius: 999px;
+      color: rgba(255,255,255,0.72);
+      transition: background 140ms ease, color 140ms ease;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .btn:hover { background: rgba(255,255,255,0.12); color: #fff; }
+    .btn:active { background: rgba(255,255,255,0.18); }
+    .btn:focus { outline: none; }
+    .btn:focus-visible { outline: none; }
+    .btn::-moz-focus-inner { border: 0; }
+    .btn svg { width: 14px; height: 14px; display: block; }
+    .btn.reset {
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      padding: 0 10px 0 12px;
+      gap: 6px;
+      color: rgba(255,255,255,0.72);
+    }
+    .btn.reset .kbd {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 16px;
+      height: 16px;
+      padding: 0 4px;
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 10px;
+      line-height: 1;
+      color: rgba(255,255,255,0.88);
+      background: rgba(255,255,255,0.12);
+      border-radius: 4px;
+    }
+
+    .count {
+      font-variant-numeric: tabular-nums;
+      color: #fff;
+      font-weight: 500;
+      padding: 0 8px;
+      min-width: 42px;
+      text-align: center;
+      font-size: 12px;
+    }
+    .count .sep { color: rgba(255,255,255,0.45); margin: 0 3px; font-weight: 400; }
+    .count .total { color: rgba(255,255,255,0.55); }
+
+    .divider {
+      width: 1px;
+      height: 14px;
+      background: rgba(255,255,255,0.18);
+      margin: 0 2px;
+    }
+
+    /* ── Thumbnail rail ──────────────────────────────────────────────────
+       Fixed column on the left; each thumbnail is a static deep-clone of
+       the light-DOM slide scaled into a 16:9 (or design-aspect) frame. The
+       stage re-fits around it (see _fit); hidden during present / noscale
+       / print so capture geometry and fullscreen output are unchanged. */
+    .rail {
+      position: fixed;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: var(--deck-rail-w, 188px);
+      background: #141414;
+      border-right: 1px solid rgba(255,255,255,0.08);
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding: 12px 10px;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      z-index: 2147482500;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255,255,255,0.18) transparent;
+    }
+    .rail::-webkit-scrollbar { width: 8px; }
+    .rail::-webkit-scrollbar-track { background: transparent; margin: 2px; }
+    .rail::-webkit-scrollbar-thumb {
+      background: rgba(255,255,255,0.18);
+      border-radius: 4px;
+      border: 2px solid transparent;
+      background-clip: content-box;
+    }
+    .rail::-webkit-scrollbar-thumb:hover {
+      background: rgba(255,255,255,0.28);
+      border: 2px solid transparent;
+      background-clip: content-box;
+    }
+    :host([no-rail]) .rail,
+    :host([noscale]) .rail { display: none; }
+    .rail[data-presenting] { display: none; }
+    /* User-driven show/hide (the TweaksPanel toggle) slides instead of
+       popping. Transitions are gated on :host([data-rail-anim]) — set only
+       for the 200ms around the toggle — so window-resize and rail-width
+       drag (which also call _fit) don't lag behind the cursor. */
+    .rail[data-user-hidden] { transform: translateX(-100%); }
+    :host([data-rail-anim]) .rail { transition: transform 200ms cubic-bezier(.3,.7,.4,1); }
+    :host([data-rail-anim]) .stage { transition: left 200ms cubic-bezier(.3,.7,.4,1); }
+    :host([data-rail-anim]) .canvas { transition: transform 200ms cubic-bezier(.3,.7,.4,1); }
+    /* transition shorthand replaces rather than merges — repeat the base
+       .overlay opacity/transform/filter transitions so visibility changes
+       during the 200ms toggle window still fade instead of popping. */
+    :host([data-rail-anim]) .overlay {
+      transition: margin-left 200ms cubic-bezier(.3,.7,.4,1),
+                  opacity 260ms ease,
+                  transform 260ms cubic-bezier(.2,.8,.2,1),
+                  filter 260ms ease;
+    }
+    :host([data-rail-anim]) .tapzones { transition: left 200ms cubic-bezier(.3,.7,.4,1); }
+
+    .thumb {
+      position: relative;
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .thumb .num {
+      width: 16px;
+      flex-shrink: 0;
+      font-size: 11px;
+      font-weight: 500;
+      text-align: right;
+      color: rgba(255,255,255,0.55);
+      padding-top: 2px;
+      font-variant-numeric: tabular-nums;
+    }
+    .thumb .frame {
+      position: relative;
+      flex: 1;
+      min-width: 0;
+      aspect-ratio: var(--deck-aspect);
+      background: #fff;
+      border-radius: 4px;
+      outline: 2px solid transparent;
+      outline-offset: 0;
+      overflow: hidden;
+      transition: outline-color 120ms ease;
+    }
+    .thumb:hover .frame { outline-color: rgba(255,255,255,0.25); }
+    .thumb { outline: none; }
+    .thumb:focus-visible .frame { outline-color: rgba(255,255,255,0.5); }
+    .thumb[data-current] .num { color: #fff; }
+    .thumb[data-current] .frame { outline-color: #D97757; }
+    .thumb[data-dragging] { opacity: 0.35; }
+    .thumb::before {
+      content: '';
+      position: absolute;
+      left: 24px;
+      right: 0;
+      height: 3px;
+      border-radius: 2px;
+      background: #D97757;
+      opacity: 0;
+      pointer-events: none;
+    }
+    .thumb[data-drop="before"]::before { top: -8px; opacity: 1; }
+    .thumb[data-drop="after"]::before { bottom: -8px; opacity: 1; }
+    .thumb[data-skip] .frame { opacity: 0.35; }
+    .thumb[data-skip] .frame::after {
+      content: 'Skipped';
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.45);
+      color: #fff;
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+    }
+
+    .ctxmenu {
+      position: fixed;
+      min-width: 150px;
+      padding: 4px;
+      background: #242424;
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 7px;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.45);
+      z-index: 2147483100;
+      display: none;
+      font-size: 12px;
+    }
+    .ctxmenu[data-open] { display: block; }
+    .ctxmenu button {
+      display: block;
+      width: 100%;
+      appearance: none;
+      border: 0;
+      background: transparent;
+      color: #e8e8e8;
+      font: inherit;
+      text-align: left;
+      padding: 6px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .ctxmenu button:hover:not(:disabled) { background: rgba(255,255,255,0.08); }
+    .ctxmenu button:disabled { opacity: 0.35; cursor: default; }
+    .ctxmenu hr {
+      border: 0;
+      border-top: 1px solid rgba(255,255,255,0.1);
+      margin: 4px 2px;
+    }
+
+    .rail-resize {
+      position: fixed;
+      left: calc(var(--deck-rail-w, 188px) - 3px);
+      top: 0;
+      bottom: 0;
+      width: 6px;
+      cursor: col-resize;
+      z-index: 2147482600;
+      touch-action: none;
+    }
+    .rail-resize:hover,
+    .rail-resize[data-dragging] { background: rgba(255,255,255,0.12); }
+    :host([no-rail]) .rail-resize,
+    :host([noscale]) .rail-resize,
+    .rail[data-presenting] + .rail-resize,
+    .rail[data-user-hidden] + .rail-resize { display: none; }
+
+    /* Delete-confirm popup — matches the SPA's ConfirmDialog layout
+       (title + message body, depressed footer with Cancel / Delete). */
+    .confirm-backdrop {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.45);
+      z-index: 2147483200;
+      display: none;
+      align-items: center;
+      justify-content: center;
+    }
+    .confirm-backdrop[data-open] { display: flex; }
+    .confirm {
+      width: 320px;
+      max-width: calc(100vw - 32px);
+      background: #2a2a2a;
+      color: #e8e8e8;
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 12px;
+      box-shadow: 0 12px 32px rgba(0,0,0,0.5);
+      overflow: hidden;
+      font-family: inherit;
+      animation: deck-confirm-in 0.18s ease;
+    }
+    @keyframes deck-confirm-in {
+      from { opacity: 0; transform: scale(0.96); }
+      to { opacity: 1; transform: scale(1); }
+    }
+    .confirm .body { padding: 20px 20px 16px; }
+    .confirm .title { font-size: 14px; font-weight: 600; margin-bottom: 4px; }
+    .confirm .msg { font-size: 13px; line-height: 1.5; color: rgba(255,255,255,0.65); }
+    .confirm .footer {
+      padding: 14px 20px;
+      background: #1f1f1f;
+      border-top: 1px solid rgba(255,255,255,0.08);
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+    }
+    .confirm button {
+      appearance: none;
+      font: inherit;
+      font-size: 13px;
+      font-weight: 500;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+    .confirm .cancel {
+      background: transparent;
+      border: 0;
+      color: rgba(255,255,255,0.8);
+    }
+    .confirm .cancel:hover { background: rgba(255,255,255,0.08); }
+    .confirm .danger {
+      background: #c96442;
+      border: 1px solid rgba(0,0,0,0.15);
+      color: #fff;
+      box-shadow: 0 1px 3px rgba(166,50,68,0.3), 0 2px 6px rgba(166,50,68,0.18);
+    }
+    .confirm .danger:hover { background: #b5563a; }
+
+    /* ── Print: one page per slide, no chrome ────────────────────────────
+       The screen layout stacks every slide at inset:0 inside a scaled
+       canvas; for print we want them in document flow at the authored
+       design size so the browser paginates one slide per sheet. The
+       @page size is set from the width/height attributes via the inline
+       <style id="deck-stage-print-page"> that connectedCallback injects
+       into <head> (the @page at-rule has no effect inside shadow DOM). */
+    @media print {
+      :host {
+        position: static;
+        inset: auto;
+        background: none;
+        overflow: visible;
+        color: inherit;
+      }
+      .stage { position: static; display: block; }
+      .canvas {
+        transform: none !important;
+        width: auto !important;
+        height: auto !important;
+        background: none;
+        will-change: auto;
+      }
+      ::slotted(*) {
+        position: relative !important;
+        inset: auto !important;
+        width: var(--deck-design-w) !important;
+        height: var(--deck-design-h) !important;
+        box-sizing: border-box !important;
+        opacity: 1 !important;
+        visibility: visible !important;
+        pointer-events: auto;
+        break-after: page;
+        page-break-after: always;
+        break-inside: avoid;
+        overflow: hidden;
+      }
+      /* :last-child alone isn't enough once data-deck-skip hides the
+         trailing slide(s) — the last *visible* slide still carries
+         break-after:page and prints a blank sheet. _markLastVisible()
+         maintains data-deck-last-visible on the last non-skipped slide. */
+      ::slotted(*:last-child),
+      ::slotted([data-deck-last-visible]) {
+        break-after: auto;
+        page-break-after: auto;
+      }
+      ::slotted([data-deck-skip]) { display: none !important; }
+      .overlay, .tapzones, .rail, .rail-resize, .ctxmenu, .confirm-backdrop { display: none !important; }
+    }
+  `;
+
+  class DeckStage extends HTMLElement {
+    static get observedAttributes() { return ['width', 'height', 'noscale', 'no-rail']; }
+
+    constructor() {
+      super();
+      this._root = this.attachShadow({ mode: 'open' });
+      this._index = 0;
+      this._slides = [];
+      this._notes = [];
+      this._hideTimer = null;
+      this._mouseIdleTimer = null;
+      this._menuIndex = -1;
+
+      this._onKey = this._onKey.bind(this);
+      this._onResize = this._onResize.bind(this);
+      this._onSlotChange = this._onSlotChange.bind(this);
+      this._onMouseMove = this._onMouseMove.bind(this);
+      this._onTapBack = this._onTapBack.bind(this);
+      this._onTapForward = this._onTapForward.bind(this);
+      this._onMessage = this._onMessage.bind(this);
+      // Capture-phase close so a click anywhere dismisses the menu, but
+      // ignore clicks that land inside the menu itself — otherwise the
+      // capture handler runs before the menu's own (bubble) handler and
+      // clears _menuIndex out from under it.
+      this._onDocClick = (e) => {
+        if (this._menu && e.composedPath && e.composedPath().includes(this._menu)) return;
+        this._closeMenu();
+      };
+    }
+
+    get designWidth() {
+      return parseInt(this.getAttribute('width'), 10) || DESIGN_W_DEFAULT;
+    }
+    get designHeight() {
+      return parseInt(this.getAttribute('height'), 10) || DESIGN_H_DEFAULT;
+    }
+
+    connectedCallback() {
+      // Presenter-view popup loads deckUrl?_snthumb=...#N for its prev/cur/
+      // next thumbnails — the rail has no business rendering inside those
+      // (wrong scale, and it offsets the stage so the thumb shows a gutter).
+      if (/[?&]_snthumb=/.test(location.search)) this.setAttribute('no-rail', '');
+      this._render();
+      this._loadNotes();
+      this._syncPrintPageRule();
+      window.addEventListener('keydown', this._onKey);
+      window.addEventListener('resize', this._onResize);
+      window.addEventListener('mousemove', this._onMouseMove, { passive: true });
+      window.addEventListener('message', this._onMessage);
+      window.addEventListener('click', this._onDocClick, true);
+      // Initial collection + layout happens via slotchange, which fires on mount.
+      this._enableRail();
+      // Hold the stage hidden until webfonts are ready so the first visible
+      // paint has the deck's real typography — the :not(:defined) guard in
+      // the page HTML only covers custom-element upgrade, not font load.
+      // Capped so a 404'd font URL can't blank the deck indefinitely.
+      this.setAttribute('data-fonts-pending', '');
+      const reveal = () => this.removeAttribute('data-fonts-pending');
+      // rAF first: fonts.ready is a pre-resolved promise until layout has
+      // resolved the slotted text's font-family and pushed a FontFace into
+      // 'loading'. Reading it here in connectedCallback (parse-time) would
+      // settle the race in a microtask before any font fetch starts.
+      requestAnimationFrame(() => {
+        Promise.race([
+          document.fonts ? document.fonts.ready : Promise.resolve(),
+          new Promise((r) => setTimeout(r, 2000)),
+        ]).then(reveal, reveal);
+      });
+    }
+
+    _enableRail() {
+      // Idempotent — older host builds still post __omelette_rail_enabled.
+      // no-rail guard keeps the observers/stylesheet walk off the cheap path
+      // for presenter-popup thumbnail iframes (up to 9 per view).
+      if (this._railEnabled || this.hasAttribute('no-rail')) return;
+      this._railEnabled = true;
+      // Per-viewer preference — restored alongside rail width. Default on;
+      // only a stored '0' (from the TweaksPanel toggle) hides it.
+      this._railVisible = true;
+      try {
+        if (localStorage.getItem('deck-stage.railVisible') === '0') this._railVisible = false;
+      } catch (e) {}
+      // Live thumbnail updates: watch the light-DOM slides for content
+      // edits and re-clone just the affected thumb(s), debounced. Ignore
+      // the data-deck-* / data-screen-label / data-om-validate attributes
+      // this component itself writes so nav and skip don't trigger
+      // spurious refreshes.
+      const OWN_ATTRS = /^data-(deck-|screen-label$|om-validate$)/;
+      this._liveDirty = new Set();
+      this._liveObserver = new MutationObserver((records) => {
+        for (const r of records) {
+          if (r.type === 'attributes' && OWN_ATTRS.test(r.attributeName || '')) continue;
+          let n = r.target;
+          while (n && n.parentElement !== this) n = n.parentElement;
+          if (n && this._slideSet && this._slideSet.has(n)) this._liveDirty.add(n);
+        }
+        if (this._liveDirty.size && !this._liveTimer) {
+          this._liveTimer = setTimeout(() => {
+            this._liveTimer = null;
+            this._liveDirty.forEach((s) => this._refreshThumb(s));
+            this._liveDirty.clear();
+          }, 200);
+        }
+      });
+      this._liveObserver.observe(this, {
+        subtree: true, childList: true, characterData: true, attributes: true,
+      });
+      // Lazy thumbnail materialization — clone the slide only when its
+      // frame scrolls into (or near) the rail viewport. rootMargin gives
+      // ~4 thumbs of pre-load so fast scrolling doesn't flash blanks.
+      this._railObserver = new IntersectionObserver((entries) => {
+        entries.forEach((e) => {
+          if (e.isIntersecting && e.target.__deckThumb) {
+            this._materialize(e.target.__deckThumb);
+          }
+        });
+      }, { root: this._rail, rootMargin: '400px 0px' });
+      // Tweaks typically change CSS vars / attrs OUTSIDE <deck-stage>
+      // (on <html>, <body>, a wrapper div, or a <style> tag), which
+      // _liveObserver can't see. Re-snapshot author CSS (constructable
+      // sheet is shared by reference, so one replaceSync updates every
+      // thumb shadow root) and re-sync each thumb host's attrs + custom
+      // properties. In-slide DOM mutations are _liveObserver's job.
+      // Debounced so slider drags don't thrash.
+      this._onTweakChange = () => {
+        clearTimeout(this._tweakTimer);
+        this._tweakTimer = setTimeout(() => {
+          this._snapshotAuthorCss();
+          // One getComputedStyle for the whole batch — each
+          // getPropertyValue read below reuses the same computed style
+          // as long as nothing invalidates layout between thumbs.
+          const cs = getComputedStyle(this);
+          (this._thumbs || []).forEach((t) => {
+            if (t.host) this._syncThumbHostAttrs(t.host, cs);
+          });
+        }, 120);
+      };
+      window.addEventListener('tweakchange', this._onTweakChange);
+      this._snapshotAuthorCss();
+      // Build the rail now that it's enabled — slotchange already fired,
+      // so _renderRail's early-return skipped the initial build.
+      this._syncRailHidden();
+      this._renderRail();
+      this._fit();
+    }
+
+    /** Snapshot document stylesheets into a constructable sheet that each
+     *  thumbnail's nested shadow root adopts — so author CSS styles the
+     *  cloned slide content without touching this component's chrome.
+     *  Cross-origin sheets throw on .cssRules — skip them. Re-callable:
+     *  the existing constructable sheet is reused via replaceSync so every
+     *  already-adopted shadow root picks up the fresh CSS without re-adopt. */
+    _snapshotAuthorCss() {
+      // :root in an adopted sheet inside a shadow root matches nothing
+      // (only the document root qualifies), so author rules like
+      // `:root[data-voice="modern"] .serif` never reach the clones.
+      // Rewrite :root → :host and mirror <html>'s data-*/class/lang onto
+      // each thumb host (see _syncThumbHostAttrs) so the same selectors
+      // match inside the thumbnail's shadow tree.
+      const authorCss = Array.from(document.styleSheets).map((sh) => {
+        try {
+          return Array.from(sh.cssRules).map((r) => r.cssText).join('\n');
+        } catch (e) { return ''; }
+      }).join('\n')
+        // The shadow host is featureless outside the functional :host(...)
+        // form, so any compound on :root — [attr], .class, #id, :pseudo —
+        // must become :host(<compound>) not :host<compound>. Same for the
+        // html type selector (Tailwind class-strategy dark mode emits
+        // html.dark; Pico uses html[data-theme]), which has nothing to
+        // match inside the thumb's shadow tree.
+        .replace(/:root((?:\[[^\]]*\]|[.#][-\w]+|:[-\w]+(?:\([^)]*\))?)+)/g, ':host($1)')
+        .replace(/:root\b/g, ':host')
+        .replace(/(^|[\s,>~+(}])html((?:\[[^\]]*\]|[.#][-\w]+|:[-\w]+(?:\([^)]*\))?)+)(?![-\w])/g, '$1:host($2)')
+        .replace(/(^|[\s,>~+(}])html(?![-\w])/g, '$1:host');
+      // Every custom property the author references. _syncThumbHostAttrs
+      // mirrors each one's *computed* value at <deck-stage> onto the
+      // thumb host so the live value wins over the :host default above
+      // regardless of which ancestor the tweak wrote to (<html>, <body>,
+      // a wrapper div, or the deck-stage element itself all inherit
+      // down to getComputedStyle(this)).
+      this._authorVars = new Set(authorCss.match(/--[\w-]+/g) || []);
+      try {
+        if (!this._adoptedSheet) this._adoptedSheet = new CSSStyleSheet();
+        this._adoptedSheet.replaceSync(authorCss);
+      } catch (e) {
+        this._adoptedSheet = null;
+        this._authorCss = authorCss;
+      }
+    }
+
+    _syncThumbHostAttrs(host, cs) {
+      const de = document.documentElement;
+      // setAttribute overwrites but can't delete — an attr removed from
+      // <html> (toggleAttribute off, classList emptied) would linger on
+      // the host and :host([data-*]) / :host(.foo) rules would keep
+      // matching. Remove stale mirrored attrs first; iterate backward
+      // because removeAttribute mutates the live NamedNodeMap.
+      for (let i = host.attributes.length - 1; i >= 0; i--) {
+        const n = host.attributes[i].name;
+        if ((n.startsWith('data-') || n === 'class' || n === 'lang')
+            && !de.hasAttribute(n)) {
+          host.removeAttribute(n);
+        }
+      }
+      for (const a of de.attributes) {
+        if (a.name.startsWith('data-') || a.name === 'class' || a.name === 'lang') {
+          host.setAttribute(a.name, a.value);
+        }
+      }
+      // The :root→:host rewrite in _snapshotAuthorCss pins each custom
+      // property to its stylesheet default on the thumb host, shadowing
+      // the live value that would otherwise inherit. Tweaks can write the
+      // live value on any ancestor — <html>, <body>, a wrapper div, the
+      // deck-stage element — so read it as the *computed* value at
+      // <deck-stage> (which sees the whole inheritance chain) rather than
+      // trying to guess which element the author wrote to. Inline on the
+      // host beats the :host{} rule. remove-stale covers vars dropped
+      // from the stylesheet between snapshots.
+      const vars = this._authorVars || new Set();
+      for (let i = host.style.length - 1; i >= 0; i--) {
+        const p = host.style[i];
+        if (p.startsWith('--') && !vars.has(p)) host.style.removeProperty(p);
+      }
+      const live = cs || getComputedStyle(this);
+      vars.forEach((p) => {
+        const v = live.getPropertyValue(p);
+        if (v) host.style.setProperty(p, v.trim());
+        else host.style.removeProperty(p);
+      });
+    }
+
+    disconnectedCallback() {
+      window.removeEventListener('keydown', this._onKey);
+      window.removeEventListener('resize', this._onResize);
+      window.removeEventListener('mousemove', this._onMouseMove);
+      window.removeEventListener('message', this._onMessage);
+      window.removeEventListener('click', this._onDocClick, true);
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      if (this._mouseIdleTimer) clearTimeout(this._mouseIdleTimer);
+      if (this._liveTimer) clearTimeout(this._liveTimer);
+      if (this._tweakTimer) clearTimeout(this._tweakTimer);
+      if (this._railAnimTimer) clearTimeout(this._railAnimTimer);
+      if (this._scaleRaf) cancelAnimationFrame(this._scaleRaf);
+      if (this._liveObserver) this._liveObserver.disconnect();
+      if (this._railObserver) this._railObserver.disconnect();
+      if (this._onTweakChange) window.removeEventListener('tweakchange', this._onTweakChange);
+    }
+
+    attributeChangedCallback() {
+      if (this._canvas) {
+        this._canvas.style.width = this.designWidth + 'px';
+        this._canvas.style.height = this.designHeight + 'px';
+        this._canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
+        this._canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+        if (this._rail) {
+          this._rail.style.setProperty('--deck-aspect', this.designWidth + '/' + this.designHeight);
+        }
+        this._fit();
+        this._scaleThumbs();
+        this._syncPrintPageRule();
+      }
+    }
+
+    _render() {
+      const style = document.createElement('style');
+      style.textContent = stylesheet;
+
+      const stage = document.createElement('div');
+      stage.className = 'stage';
+
+      const canvas = document.createElement('div');
+      canvas.className = 'canvas';
+      canvas.style.width = this.designWidth + 'px';
+      canvas.style.height = this.designHeight + 'px';
+      canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
+      canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+
+      const slot = document.createElement('slot');
+      slot.addEventListener('slotchange', this._onSlotChange);
+      canvas.appendChild(slot);
+      stage.appendChild(canvas);
+
+      // Tap zones (mobile): left third = back, right third = forward.
+      const tapzones = document.createElement('div');
+      tapzones.className = 'tapzones export-hidden';
+      tapzones.setAttribute('aria-hidden', 'true');
+      tapzones.setAttribute('data-noncommentable', '');
+      const tzBack = document.createElement('div');
+      tzBack.className = 'tapzone tapzone--back';
+      const tzMid = document.createElement('div');
+      tzMid.className = 'tapzone tapzone--mid';
+      tzMid.style.pointerEvents = 'none';
+      const tzFwd = document.createElement('div');
+      tzFwd.className = 'tapzone tapzone--fwd';
+      tzBack.addEventListener('click', this._onTapBack);
+      tzFwd.addEventListener('click', this._onTapForward);
+      tapzones.append(tzBack, tzMid, tzFwd);
+
+      // Overlay: compact, solid black, with clickable controls.
+      const overlay = document.createElement('div');
+      overlay.className = 'overlay export-hidden';
+      overlay.setAttribute('role', 'toolbar');
+      overlay.setAttribute('aria-label', 'Deck controls');
+      overlay.setAttribute('data-noncommentable', '');
+      overlay.innerHTML = `
+        <button class="btn prev" type="button" aria-label="Previous slide" title="Previous (←)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 3L5 8l5 5"/></svg>
+        </button>
+        <span class="count" aria-live="polite"><span class="current">1</span><span class="sep">/</span><span class="total">1</span></span>
+        <button class="btn next" type="button" aria-label="Next slide" title="Next (→)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3l5 5-5 5"/></svg>
+        </button>
+        <span class="divider"></span>
+        <button class="btn reset" type="button" aria-label="Reset to first slide" title="Reset (R)">Reset<span class="kbd">R</span></button>
+      `;
+
+      overlay.querySelector('.prev').addEventListener('click', () => this._advance(-1, 'click'));
+      overlay.querySelector('.next').addEventListener('click', () => this._advance(1, 'click'));
+      overlay.querySelector('.reset').addEventListener('click', () => this._go(0, 'click'));
+
+      // Thumbnail rail + context menu. Thumbnails are populated in
+      // _renderRail() after _collectSlides().
+      const rail = document.createElement('div');
+      rail.className = 'rail export-hidden';
+      rail.setAttribute('data-noncommentable', '');
+      rail.style.setProperty('--deck-aspect', this.designWidth + '/' + this.designHeight);
+      // Edge auto-scroll while dragging a thumb near the rail's top/bottom
+      // so off-screen drop targets are reachable. Native dragover fires
+      // continuously while the pointer is stationary, so a per-event nudge
+      // (ramped by edge proximity) is enough — no rAF loop needed.
+      rail.addEventListener('dragover', (e) => {
+        if (this._dragFrom == null) return;
+        const r = rail.getBoundingClientRect();
+        const EDGE = 40;
+        const dt = e.clientY - r.top;
+        const db = r.bottom - e.clientY;
+        if (dt < EDGE) rail.scrollTop -= Math.ceil((EDGE - dt) / 3);
+        else if (db < EDGE) rail.scrollTop += Math.ceil((EDGE - db) / 3);
+      });
+
+      const menu = document.createElement('div');
+      menu.className = 'ctxmenu export-hidden';
+      menu.setAttribute('data-noncommentable', '');
+      menu.innerHTML = `
+        <button type="button" data-act="skip">Skip slide</button>
+        <button type="button" data-act="up">Move up</button>
+        <button type="button" data-act="down">Move down</button>
+        <hr>
+        <button type="button" data-act="delete">Delete slide</button>
+      `;
+      menu.addEventListener('click', (e) => {
+        const act = e.target && e.target.getAttribute && e.target.getAttribute('data-act');
+        if (!act) return;
+        const i = this._menuIndex;
+        this._closeMenu();
+        if (act === 'skip') this._toggleSkip(i);
+        else if (act === 'up') this._moveSlide(i, i - 1);
+        else if (act === 'down') this._moveSlide(i, i + 1);
+        else if (act === 'delete') this._openConfirm(i);
+      });
+      menu.addEventListener('contextmenu', (e) => e.preventDefault());
+
+      // Rail resize handle — drag to set --deck-rail-w, persisted to
+      // localStorage so the width survives reloads.
+      const resize = document.createElement('div');
+      resize.className = 'rail-resize export-hidden';
+      resize.setAttribute('data-noncommentable', '');
+      resize.addEventListener('pointerdown', (e) => {
+        e.preventDefault();
+        resize.setPointerCapture(e.pointerId);
+        resize.setAttribute('data-dragging', '');
+        const move = (ev) => this._setRailWidth(ev.clientX);
+        const up = () => {
+          resize.removeEventListener('pointermove', move);
+          resize.removeEventListener('pointerup', up);
+          resize.removeEventListener('pointercancel', up);
+          resize.removeAttribute('data-dragging');
+          try { localStorage.setItem('deck-stage.railWidth', String(this._railPx)); } catch (err) {}
+        };
+        resize.addEventListener('pointermove', move);
+        resize.addEventListener('pointerup', up);
+        resize.addEventListener('pointercancel', up);
+      });
+
+      // Delete-confirm dialog — mirrors the SPA's ConfirmDialog layout.
+      const confirm = document.createElement('div');
+      confirm.className = 'confirm-backdrop export-hidden';
+      confirm.setAttribute('data-noncommentable', '');
+      confirm.innerHTML = `
+        <div class="confirm" role="dialog" aria-modal="true">
+          <div class="body">
+            <div class="title">Delete slide?</div>
+            <div class="msg">This slide will be removed from the deck.</div>
+          </div>
+          <div class="footer">
+            <button type="button" class="cancel">Cancel</button>
+            <button type="button" class="danger">Delete</button>
+          </div>
+        </div>
+      `;
+      confirm.addEventListener('click', (e) => {
+        if (e.target === confirm) this._closeConfirm();
+      });
+      confirm.querySelector('.cancel').addEventListener('click', () => this._closeConfirm());
+      confirm.querySelector('.danger').addEventListener('click', () => {
+        const i = this._confirmIndex;
+        this._closeConfirm();
+        this._deleteSlide(i);
+      });
+
+      this._root.append(style, rail, resize, stage, tapzones, overlay, menu, confirm);
+      this._canvas = canvas;
+      this._slot = slot;
+      this._overlay = overlay;
+      this._tapzones = tapzones;
+      this._rail = rail;
+      this._resize = resize;
+      this._menu = menu;
+      this._confirm = confirm;
+      this._countEl = overlay.querySelector('.current');
+      this._totalEl = overlay.querySelector('.total');
+
+      // Restore persisted rail width.
+      let rw = 188;
+      try {
+        const s = localStorage.getItem('deck-stage.railWidth');
+        if (s) rw = parseInt(s, 10) || rw;
+      } catch (err) {}
+      this._setRailWidth(rw);
+      this._syncRailHidden();
+    }
+
+    _setRailWidth(px) {
+      const w = Math.max(120, Math.min(360, Math.round(px)));
+      this._railPx = w;
+      this.style.setProperty('--deck-rail-w', w + 'px');
+      this._fit();
+      // _scaleThumbs forces a sync layout (frame.offsetWidth) then writes
+      // N transforms. During a resize drag this runs per-pointermove;
+      // coalesce to one per frame.
+      if (!this._scaleRaf) {
+        this._scaleRaf = requestAnimationFrame(() => {
+          this._scaleRaf = null;
+          this._scaleThumbs();
+        });
+      }
+    }
+
+    /** @page must live in the document stylesheet — it's a no-op inside
+     *  shadow DOM. Inject/update a single <head> style tag so the print
+     *  sheet matches the design size and Save-as-PDF yields one slide per
+     *  page with no margins. */
+    _syncPrintPageRule() {
+      const id = 'deck-stage-print-page';
+      let tag = document.getElementById(id);
+      if (!tag) {
+        tag = document.createElement('style');
+        tag.id = id;
+        document.head.appendChild(tag);
+      }
+      tag.textContent =
+        '@page { size: ' + this.designWidth + 'px ' + this.designHeight + 'px; margin: 0; } ' +
+        '@media print { html, body { margin: 0 !important; padding: 0 !important; background: none !important; overflow: visible !important; height: auto !important; } ' +
+        '* { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }';
+    }
+
+    _onSlotChange() {
+      // Rail mutations (delete/move) already reconcile synchronously and
+      // emit slidechange with reason 'api'; skip the async slotchange that
+      // would otherwise re-broadcast with reason 'init'.
+      if (this._squelchSlotChange) { this._squelchSlotChange = false; return; }
+      this._collectSlides();
+      this._restoreIndex();
+      this._applyIndex({ showOverlay: false, broadcast: true, reason: 'init' });
+      this._fit();
+    }
+
+    _collectSlides() {
+      const assigned = this._slot.assignedElements({ flatten: true });
+      this._slides = assigned.filter((el) => {
+        // Skip template/style/script nodes even if someone slots them.
+        const tag = el.tagName;
+        return tag !== 'TEMPLATE' && tag !== 'SCRIPT' && tag !== 'STYLE';
+      });
+      this._slideSet = new Set(this._slides);
+
+      this._slides.forEach((slide, i) => {
+        const n = i + 1;
+        slide.setAttribute('data-screen-label', `${pad2(n)} ${getSlideLabel(slide)}`);
+
+        // Validation attribute for comment flow / auto-checks.
+        if (!slide.hasAttribute('data-om-validate')) {
+          slide.setAttribute('data-om-validate', VALIDATE_ATTR);
+        }
+
+        slide.setAttribute('data-deck-slide', String(i));
+      });
+
+      if (this._totalEl) this._totalEl.textContent = String(this._slides.length || 1);
+      if (this._index >= this._slides.length) this._index = Math.max(0, this._slides.length - 1);
+      this._markLastVisible();
+      this._renderRail();
+    }
+
+    /** Tag the last non-skipped slide so print CSS can drop its
+     *  break-after (see the @media print comment above — :last-child
+     *  alone matches a hidden skipped slide). */
+    _markLastVisible() {
+      let last = null;
+      this._slides.forEach((s) => {
+        s.removeAttribute('data-deck-last-visible');
+        if (!s.hasAttribute('data-deck-skip')) last = s;
+      });
+      if (last) last.setAttribute('data-deck-last-visible', '');
+    }
+
+    _loadNotes() {
+      const tag = document.getElementById('speaker-notes');
+      if (!tag) { this._notes = []; return; }
+      try {
+        const parsed = JSON.parse(tag.textContent || '[]');
+        if (Array.isArray(parsed)) this._notes = parsed;
+      } catch (e) {
+        console.warn('[deck-stage] Failed to parse #speaker-notes JSON:', e);
+        this._notes = [];
+      }
+    }
+
+    _restoreIndex() {
+      // The host's ?slide= param is delivered as a #<int> hash (1-indexed) on
+      // the iframe src. No hash → slide 1; the deck itself keeps no position
+      // state across loads.
+      const h = (location.hash || '').match(/^#(\d+)$/);
+      if (h) {
+        const n = parseInt(h[1], 10) - 1;
+        if (n >= 0 && n < this._slides.length) this._index = n;
+      }
+    }
+
+    _applyIndex({ showOverlay = true, broadcast = true, reason = 'init' } = {}) {
+      if (!this._slides.length) return;
+      const prev = this._prevIndex == null ? -1 : this._prevIndex;
+      const curr = this._index;
+      // Keep the iframe's own hash in sync so an in-iframe location.reload()
+      // (reload banner path in viewer-handle.ts) lands on the current slide,
+      // not the stale deep-link hash from initial load.
+      try { history.replaceState(null, '', '#' + (curr + 1)); } catch (e) {}
+      this._slides.forEach((s, i) => {
+        if (i === curr) s.setAttribute('data-deck-active', '');
+        else s.removeAttribute('data-deck-active');
+      });
+      if (this._countEl) this._countEl.textContent = String(curr + 1);
+      // Follow-scroll on every navigation (init deep-link, keyboard, click,
+      // tap, external goTo) — the only time we *don't* want the rail to
+      // track current is after a rail-internal mutation, where _renderRail
+      // has already restored the user's scroll position and yanking back to
+      // current would undo it.
+      this._syncRail(reason !== 'mutation');
+
+      if (broadcast) {
+        // (1) Legacy: host-window postMessage for speaker-notes renderers.
+        try { window.postMessage({ slideIndexChanged: curr, deckTotal: this._slides.length, deckSkipped: this._skippedIndices() }, '*'); } catch (e) {}
+
+        // (2) In-page CustomEvent on the <deck-stage> element itself.
+        //     Bubbles and composes out of shadow DOM so slide code can listen:
+        //       document.querySelector('deck-stage').addEventListener('slidechange', e => {
+        //         e.detail.index, e.detail.previousIndex, e.detail.total, e.detail.slide, e.detail.reason
+        //       });
+        const detail = {
+          index: curr,
+          previousIndex: prev,
+          total: this._slides.length,
+          slide: this._slides[curr] || null,
+          previousSlide: prev >= 0 ? (this._slides[prev] || null) : null,
+          reason: reason, // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+        };
+        this.dispatchEvent(new CustomEvent('slidechange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }));
+      }
+
+      this._prevIndex = curr;
+      if (showOverlay) this._flashOverlay();
+    }
+
+    _flashOverlay() {
+      // Host posts __omelette_presenting while in fullscreen/tab presentation
+      // mode — suppress the nav footer entirely (both hover and slide-change
+      // flash) so the audience sees clean slides.
+      if (!this._overlay || this._presenting) return;
+      this._overlay.setAttribute('data-visible', '');
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      this._hideTimer = setTimeout(() => {
+        this._overlay.removeAttribute('data-visible');
+      }, OVERLAY_HIDE_MS);
+    }
+
+    _railWidth() {
+      // State-based, no offsetWidth: the first _fit() can run before the
+      // rail has had layout on some load paths, and a 0 there paints the
+      // slide full-width for one frame before the post-slotchange _fit()
+      // corrects it.
+      if (!this._railEnabled || !this._railVisible || this.hasAttribute('no-rail')
+          || this.hasAttribute('noscale') || this._presenting || this._previewMode) return 0;
+      return this._railPx || 0;
+    }
+
+    _fit() {
+      if (!this._canvas) return;
+      const stage = this._canvas.parentElement;
+      // PPTX export sets noscale so the DOM capture sees authored-size
+      // geometry — the scaled canvas is in shadow DOM, so the exporter's
+      // resetTransformSelector can't reach .canvas.style.transform directly.
+      if (this.hasAttribute('noscale')) {
+        this._canvas.style.transform = 'none';
+        if (stage) stage.style.left = '0';
+        if (this._overlay) this._overlay.style.marginLeft = '0';
+        if (this._tapzones) this._tapzones.style.left = '0';
+        return;
+      }
+      const rw = this._railWidth();
+      if (stage) stage.style.left = rw + 'px';
+      // Overlay is centred on the viewport via left:50% + translate(-50%);
+      // marginLeft shifts the centre by rw/2 so it lands in the middle of
+      // the [rw, innerWidth] stage region. Tapzones just inset from rw.
+      if (this._overlay) this._overlay.style.marginLeft = (rw / 2) + 'px';
+      if (this._tapzones) this._tapzones.style.left = rw + 'px';
+      const vw = window.innerWidth - rw;
+      const vh = window.innerHeight;
+      const s = Math.min(vw / this.designWidth, vh / this.designHeight);
+      this._canvas.style.transform = `scale(${s})`;
+    }
+
+    _onResize() { this._fit(); }
+
+    _onMouseMove() {
+      // Keep overlay visible while mouse moves; hide after idle.
+      this._flashOverlay();
+    }
+
+    _onMessage(e) {
+      const d = e.data;
+      if (d && typeof d.__omelette_presenting === 'boolean') {
+        this._presenting = d.__omelette_presenting;
+        if (this._presenting && this._overlay) {
+          this._overlay.removeAttribute('data-visible');
+          if (this._hideTimer) clearTimeout(this._hideTimer);
+        }
+        this._syncRailHidden();
+        this._closeMenu();
+        this._closeConfirm();
+        this._fit();
+        this._scaleThumbs();
+      }
+      // Host's Preview segment (ViewerMode='none'): the rail's drag-reorder /
+      // right-click skip-delete affordances are editing chrome, so hide it
+      // while the user is just looking at the deck. Same hard-hide path as
+      // presenting; independent of the user's _railVisible preference so
+      // returning to Edit restores whatever they had.
+      if (d && typeof d.__omelette_preview_mode === 'boolean') {
+        if (d.__omelette_preview_mode === this._previewMode) return;
+        this._previewMode = d.__omelette_preview_mode;
+        this._syncRailHidden();
+        this._closeMenu();
+        this._closeConfirm();
+        this._fit();
+        this._scaleThumbs();
+      }
+      // Per-viewer show/hide, driven by the TweaksPanel's auto-injected
+      // "Thumbnail rail" toggle (or any author script). Independent of
+      // whether the Tweaks panel itself is open — closing the panel
+      // doesn't change rail visibility. Persists alongside rail width.
+      if (d && d.type === '__deck_rail_visible' && typeof d.on === 'boolean') {
+        if (d.on === this._railVisible) return;
+        this._railVisible = d.on;
+        try { localStorage.setItem('deck-stage.railVisible', d.on ? '1' : '0'); } catch (e) {}
+        // Arm the transition, commit it, then flip state — otherwise the
+        // browser coalesces both writes and nothing animates on show.
+        this.setAttribute('data-rail-anim', '');
+        void (this._rail && this._rail.offsetHeight);
+        this._syncRailHidden();
+        this._fit();
+        this._scaleThumbs();
+        clearTimeout(this._railAnimTimer);
+        this._railAnimTimer = setTimeout(() => this.removeAttribute('data-rail-anim'), 220);
+      }
+      if (d && d.type === '__omelette_rail_enabled') this._enableRail();
+    }
+
+    _syncRailHidden() {
+      if (!this._rail) return;
+      // data-presenting is the hard hide (display:none) for flag-off,
+      // presentation mode, and the host's Preview segment — instant, no
+      // transition. data-user-hidden is the soft hide (translateX(-100%))
+      // for the viewer's rail toggle, so show/hide slides under
+      // :host([data-rail-anim]).
+      const hard = !this._railEnabled || this._presenting || this._previewMode;
+      if (hard) this._rail.setAttribute('data-presenting', '');
+      else this._rail.removeAttribute('data-presenting');
+      if (!this._railVisible) this._rail.setAttribute('data-user-hidden', '');
+      else this._rail.removeAttribute('data-user-hidden');
+      // translateX hide leaves thumbs (tabIndex=0) in the tab order —
+      // inert keeps them unfocusable while the rail is off-screen.
+      this._rail.inert = hard || !this._railVisible;
+    }
+
+    _onTapBack(e) {
+      e.preventDefault();
+      this._advance(-1, 'tap');
+    }
+
+    _onTapForward(e) {
+      e.preventDefault();
+      this._advance(1, 'tap');
+    }
+
+    _onKey(e) {
+      // Ignore when the user is typing.
+      const t = e.target;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      // Confirm dialog swallows nav keys while open; Escape cancels. Enter
+      // is left to the focused button's native activation so Tab→Cancel
+      // →Enter activates Cancel, not the window-level confirm path.
+      if (this._confirm && this._confirm.hasAttribute('data-open')) {
+        if (e.key === 'Escape') { this._closeConfirm(); e.preventDefault(); }
+        return;
+      }
+      if (e.key === 'Escape' && this._menu && this._menu.hasAttribute('data-open')) {
+        this._closeMenu();
+        e.preventDefault();
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const key = e.key;
+      let handled = true;
+
+      if (key === 'ArrowRight' || key === 'PageDown' || key === ' ' || key === 'Spacebar') {
+        this._advance(1, 'keyboard');
+      } else if (key === 'ArrowLeft' || key === 'PageUp') {
+        this._advance(-1, 'keyboard');
+      } else if (key === 'Home') {
+        this._go(0, 'keyboard');
+      } else if (key === 'End') {
+        this._go(this._slides.length - 1, 'keyboard');
+      } else if (key === 'r' || key === 'R') {
+        this._go(0, 'keyboard');
+      } else if (/^[0-9]$/.test(key)) {
+        // 1..9 jump to that slide; 0 jumps to 10.
+        const n = key === '0' ? 9 : parseInt(key, 10) - 1;
+        if (n < this._slides.length) this._go(n, 'keyboard');
+      } else {
+        handled = false;
+      }
+
+      if (handled) {
+        e.preventDefault();
+        this._flashOverlay();
+      }
+    }
+
+    _go(i, reason = 'api') {
+      if (!this._slides.length) return;
+      const clamped = Math.max(0, Math.min(this._slides.length - 1, i));
+      if (clamped === this._index) {
+        this._flashOverlay();
+        return;
+      }
+      this._index = clamped;
+      this._applyIndex({ showOverlay: true, broadcast: true, reason });
+    }
+
+    /** Step forward/back skipping any slide marked data-deck-skip. Falls
+     *  back to _go's clamp-at-ends behaviour (flash overlay) when there's
+     *  nothing further in that direction. */
+    _advance(dir, reason) {
+      if (!this._slides.length) return;
+      let i = this._index + dir;
+      while (i >= 0 && i < this._slides.length && this._slides[i].hasAttribute('data-deck-skip')) {
+        i += dir;
+      }
+      if (i < 0 || i >= this._slides.length) { this._flashOverlay(); return; }
+      this._go(i, reason);
+    }
+
+    // ── Thumbnail rail ────────────────────────────────────────────────────
+    //
+    // Thumbs are keyed by slide element and reused across _renderRail()
+    // calls, so a reorder/delete is an O(changed) DOM shuffle instead of an
+    // O(N) teardown-and-re-clone. Each thumb starts as a lightweight shell
+    // (num + empty frame); the clone is materialized lazily by an
+    // IntersectionObserver when the frame scrolls into (or near) view, so
+    // only visible-ish slides pay the clone + image-decode cost.
+
+    _renderRail() {
+      if (!this._rail || !this._railEnabled) { this._thumbs = []; return; }
+      // FLIP: record each *materialized* thumb's top before the reconcile.
+      // Off-screen (non-materialized) thumbs don't need the animation and
+      // skipping their getBoundingClientRect saves a forced layout per
+      // off-screen thumb on large decks.
+      const prevTops = new Map();
+      (this._thumbs || []).forEach(({ thumb, slide, host }) => {
+        if (host) prevTops.set(slide, thumb.getBoundingClientRect().top);
+      });
+      const st = this._rail.scrollTop;
+
+      // Reconcile: reuse thumbs that already exist for a slide, create
+      // shells for new slides, drop thumbs for removed slides.
+      const bySlide = new Map();
+      (this._thumbs || []).forEach((t) => bySlide.set(t.slide, t));
+      const next = [];
+      this._slides.forEach((slide) => {
+        let t = bySlide.get(slide);
+        if (t) bySlide.delete(slide);
+        else t = this._makeThumb(slide);
+        next.push(t);
+      });
+      // Orphans — slides removed since last render.
+      bySlide.forEach((t) => {
+        if (this._railObserver) this._railObserver.unobserve(t.frame);
+        t.thumb.remove();
+      });
+      // Put thumbs into document order to match _slides. insertBefore on
+      // an already-correctly-placed node is a no-op, so this is cheap
+      // when nothing moved.
+      next.forEach((t, i) => {
+        const want = t.thumb;
+        const at = this._rail.children[i];
+        if (at !== want) this._rail.insertBefore(want, at || null);
+        t.i = i;
+        t.num.textContent = String(i + 1);
+        if (t.slide.hasAttribute('data-deck-skip')) t.thumb.setAttribute('data-skip', '');
+        else t.thumb.removeAttribute('data-skip');
+      });
+      this._thumbs = next;
+
+      this._rail.scrollTop = st;
+      if (prevTops.size) {
+        const moved = [];
+        this._thumbs.forEach(({ thumb, slide }) => {
+          const old = prevTops.get(slide);
+          if (old == null) return;
+          const dy = old - thumb.getBoundingClientRect().top;
+          if (Math.abs(dy) < 1) return;
+          thumb.style.transition = 'none';
+          thumb.style.transform = `translateY(${dy}px)`;
+          moved.push(thumb);
+        });
+        if (moved.length) {
+          // Commit the inverted positions before flipping the transition
+          // on — otherwise the browser coalesces both style writes and
+          // nothing animates.
+          void this._rail.offsetHeight;
+          moved.forEach((t) => {
+            t.style.transition = 'transform 180ms cubic-bezier(.2,.7,.3,1)';
+            t.style.transform = '';
+          });
+          setTimeout(() => moved.forEach((t) => { t.style.transition = ''; }), 220);
+        }
+      }
+      requestAnimationFrame(() => this._scaleThumbs());
+      this._syncRail(false);
+    }
+
+    /** Create a lightweight thumb shell for one slide. The clone is
+     *  materialized later by the IntersectionObserver. Event handlers
+     *  look up the thumb's *current* index (via _thumbs.indexOf) so the
+     *  same element can be reused across reorders. */
+    _makeThumb(slide) {
+      const thumb = document.createElement('div');
+      thumb.className = 'thumb';
+      thumb.tabIndex = 0;
+      const num = document.createElement('div');
+      num.className = 'num';
+      const frame = document.createElement('div');
+      frame.className = 'frame';
+      thumb.append(num, frame);
+
+      const entry = { thumb, num, frame, slide, clone: null, host: null, i: -1 };
+      // entry.i is refreshed on every _renderRail reconcile pass, so
+      // handlers read the thumb's current position without an O(N) scan.
+      const idx = () => entry.i;
+
+      thumb.addEventListener('click', () => this._go(idx(), 'click'));
+      // ↑/↓ step through the rail when a thumb has focus. _go clamps at the
+      // ends and _applyIndex→_syncRail scrolls the new current thumb into
+      // view; we move focus to it (preventScroll — _syncRail already
+      // scrolled) so a held key walks the whole list. stopPropagation keeps
+      // this out of the window-level _onKey nav handler.
+      thumb.addEventListener('keydown', (e) => {
+        if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+        e.preventDefault();
+        e.stopPropagation();
+        this._go(idx() + (e.key === 'ArrowDown' ? 1 : -1), 'keyboard');
+        const cur = this._thumbs && this._thumbs[this._index];
+        if (cur) cur.thumb.focus({ preventScroll: true });
+      });
+      thumb.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        this._openMenu(idx(), e.clientX, e.clientY);
+      });
+      thumb.draggable = true;
+      thumb.addEventListener('dragstart', (e) => {
+        this._dragFrom = idx();
+        thumb.setAttribute('data-dragging', '');
+        e.dataTransfer.effectAllowed = 'move';
+        try { e.dataTransfer.setData('text/plain', String(this._dragFrom)); } catch (err) {}
+      });
+      thumb.addEventListener('dragend', () => {
+        thumb.removeAttribute('data-dragging');
+        this._clearDrop();
+        this._dragFrom = null;
+      });
+      thumb.addEventListener('dragover', (e) => {
+        if (this._dragFrom == null) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        const r = thumb.getBoundingClientRect();
+        this._setDrop(idx(), e.clientY < r.top + r.height / 2 ? 'before' : 'after');
+      });
+      thumb.addEventListener('drop', (e) => {
+        if (this._dragFrom == null) return;
+        e.preventDefault();
+        const i = idx();
+        const r = thumb.getBoundingClientRect();
+        let to = e.clientY >= r.top + r.height / 2 ? i + 1 : i;
+        if (this._dragFrom < to) to--;
+        const from = this._dragFrom;
+        this._clearDrop();
+        this._dragFrom = null;
+        if (to !== from) this._moveSlide(from, to);
+      });
+
+      if (this._railObserver) this._railObserver.observe(frame);
+      frame.__deckThumb = entry;
+      return entry;
+    }
+
+    /** Lazily build the clone for a thumb that has scrolled into view. */
+    _materialize(entry) {
+      if (entry.host) return;
+      const dw = this.designWidth, dh = this.designHeight;
+      let clone = entry.slide.cloneNode(true);
+      clone.removeAttribute('id');
+      clone.removeAttribute('data-deck-active');
+      clone.querySelectorAll('[id]').forEach((el) => el.removeAttribute('id'));
+      // Neuter heavy media; replace <video> with its poster so the box
+      // keeps a visual. <iframe>/<audio> become empty placeholders.
+      clone.querySelectorAll('iframe, audio, object, embed').forEach((el) => {
+        el.removeAttribute('src');
+        el.removeAttribute('srcdoc');
+        el.removeAttribute('data');
+        el.innerHTML = '';
+      });
+      clone.querySelectorAll('video').forEach((el) => {
+        if (!el.poster) { el.removeAttribute('src'); el.innerHTML = ''; return; }
+        const img = document.createElement('img');
+        img.src = el.poster;
+        img.alt = '';
+        img.style.cssText = el.style.cssText + ';object-fit:cover;width:100%;height:100%;';
+        img.className = el.className;
+        el.replaceWith(img);
+      });
+      // Images: defer decode and let the browser pick the smallest
+      // srcset candidate for the ~140px thumb. Same-URL clones reuse the
+      // slide's decoded bitmap (URL-keyed cache), so the remaining cost
+      // is paint/composite — lazy+async keeps that off the main thread.
+      clone.querySelectorAll('img').forEach((el) => {
+        el.loading = 'lazy';
+        el.decoding = 'async';
+        if (el.srcset) el.sizes = (this._railPx || 188) + 'px';
+      });
+      // Custom elements inside the slide would have their
+      // connectedCallback fire when the clone is appended. Replace them
+      // with inert boxes so a component-heavy deck doesn't run N copies
+      // of each component's mount logic in the rail. Children are
+      // preserved so layout-wrapper elements (<my-column><h2>…</h2>)
+      // still show their authored content; the querySelectorAll NodeList
+      // is static, so nested custom elements in the moved subtree are
+      // still visited on later iterations.
+      const neuter = (el) => {
+        const box = document.createElement('div');
+        box.style.cssText = (el.getAttribute('style') || '') +
+          ';background:rgba(0,0,0,0.06);border:1px dashed rgba(0,0,0,0.15);';
+        box.className = el.className;
+        // Preserve theming/i18n hooks so [data-*] / :lang() / [dir]
+        // descendant selectors still match the neutered root.
+        for (const a of el.attributes) {
+          const n = a.name;
+          if (n.startsWith('data-') || n.startsWith('aria-') ||
+              n === 'lang' || n === 'dir' || n === 'role' || n === 'title') {
+            box.setAttribute(n, a.value);
+          }
+        }
+        while (el.firstChild) box.appendChild(el.firstChild);
+        return box;
+      };
+      // querySelectorAll('*') returns descendants only — a custom-element
+      // slide root (<my-slide>…</my-slide>) would slip through and upgrade
+      // on append. Swap the root first.
+      if (clone.tagName.includes('-')) clone = neuter(clone);
+      clone.querySelectorAll('*').forEach((el) => {
+        if (el.tagName.includes('-')) el.replaceWith(neuter(el));
+      });
+      clone.style.cssText += ';position:absolute;top:0;left:0;transform-origin:0 0;' +
+        'pointer-events:none;width:' + dw + 'px;height:' + dh + 'px;' +
+        'box-sizing:border-box;overflow:hidden;visibility:visible;opacity:1;';
+      const host = document.createElement('div');
+      host.style.cssText = 'position:absolute;inset:0;';
+      this._syncThumbHostAttrs(host);
+      const sr = host.attachShadow({ mode: 'open' });
+      if (this._adoptedSheet) sr.adoptedStyleSheets = [this._adoptedSheet];
+      else {
+        const st = document.createElement('style');
+        st.textContent = this._authorCss || '';
+        sr.appendChild(st);
+      }
+      sr.appendChild(clone);
+      entry.frame.appendChild(host);
+      entry.host = host;
+      entry.clone = clone;
+      if (this._thumbScale) clone.style.transform = 'scale(' + this._thumbScale + ')';
+      // Once materialized the IO callback is a no-op early-return —
+      // unobserve so scroll doesn't keep firing it.
+      if (this._railObserver) this._railObserver.unobserve(entry.frame);
+    }
+
+    /** Re-clone a single thumb (live-update path). No-op if the thumb
+     *  hasn't been materialized yet — it'll pick up current content when
+     *  it scrolls into view. */
+    _refreshThumb(slide) {
+      const entry = (this._thumbs || []).find((t) => t.slide === slide);
+      if (!entry || !entry.host) return;
+      entry.host.remove();
+      entry.host = entry.clone = null;
+      this._materialize(entry);
+    }
+
+    _scaleThumbs() {
+      if (!this._thumbs || !this._thumbs.length) return;
+      // Every frame is the same width; if it reads 0 the rail is
+      // display:none (noscale / no-rail / presenting / print) — leave the
+      // clones as-is and re-run when the rail is revealed.
+      const fw = this._thumbs[0].frame.offsetWidth;
+      if (!fw) return;
+      this._thumbScale = fw / this.designWidth;
+      this._thumbs.forEach(({ clone }) => {
+        if (clone) clone.style.transform = 'scale(' + this._thumbScale + ')';
+      });
+    }
+
+    _setDrop(i, where) {
+      // dragover fires at pointer-event rate; touch only the previous
+      // and new target rather than sweeping all N thumbs.
+      const t = this._thumbs && this._thumbs[i];
+      if (this._dropOn && this._dropOn !== t) {
+        this._dropOn.thumb.removeAttribute('data-drop');
+      }
+      if (t) t.thumb.setAttribute('data-drop', where);
+      this._dropOn = t || null;
+    }
+
+    _clearDrop() {
+      if (this._dropOn) this._dropOn.thumb.removeAttribute('data-drop');
+      this._dropOn = null;
+    }
+
+    _syncRail(follow) {
+      if (!this._thumbs) return;
+      this._thumbs.forEach(({ thumb }, i) => {
+        if (i === this._index) {
+          thumb.setAttribute('data-current', '');
+          if (follow && typeof thumb.scrollIntoView === 'function') {
+            thumb.scrollIntoView({ block: 'nearest' });
+          }
+        } else {
+          thumb.removeAttribute('data-current');
+        }
+      });
+    }
+
+    _openMenu(i, x, y) {
+      if (!this._menu) return;
+      this._menuIndex = i;
+      const slide = this._slides[i];
+      const skip = slide && slide.hasAttribute('data-deck-skip');
+      this._menu.querySelector('[data-act="skip"]').textContent = skip ? 'Unskip slide' : 'Skip slide';
+      this._menu.querySelector('[data-act="up"]').disabled = i <= 0;
+      this._menu.querySelector('[data-act="down"]').disabled = i >= this._slides.length - 1;
+      this._menu.querySelector('[data-act="delete"]').disabled = this._slides.length <= 1;
+      // Place, then clamp to viewport after it's measurable.
+      this._menu.style.left = x + 'px';
+      this._menu.style.top = y + 'px';
+      this._menu.setAttribute('data-open', '');
+      const r = this._menu.getBoundingClientRect();
+      const nx = Math.min(x, window.innerWidth - r.width - 4);
+      const ny = Math.min(y, window.innerHeight - r.height - 4);
+      this._menu.style.left = Math.max(4, nx) + 'px';
+      this._menu.style.top = Math.max(4, ny) + 'px';
+    }
+
+    _closeMenu() {
+      if (this._menu) this._menu.removeAttribute('data-open');
+      this._menuIndex = -1;
+    }
+
+    _openConfirm(i) {
+      if (!this._confirm) return;
+      this._confirmIndex = i;
+      this._confirm.querySelector('.title').textContent = 'Delete slide ' + (i + 1) + '?';
+      this._confirm.setAttribute('data-open', '');
+      const btn = this._confirm.querySelector('.danger');
+      if (btn && btn.focus) btn.focus();
+    }
+
+    _closeConfirm() {
+      if (this._confirm) this._confirm.removeAttribute('data-open');
+      this._confirmIndex = -1;
+    }
+
+    _emitDeckChange(detail) {
+      this.dispatchEvent(new CustomEvent('deckchange', {
+        detail, bubbles: true, composed: true,
+      }));
+    }
+
+    _deleteSlide(i) {
+      const slide = this._slides[i];
+      if (!slide || this._slides.length <= 1) return;
+      const wasCurrent = i === this._index;
+      if (i < this._index || (wasCurrent && i === this._slides.length - 1)) this._index--;
+      this._squelchSlotChange = true;
+      slide.remove();
+      this._emitDeckChange({ action: 'delete', from: i, slide });
+      this._collectSlides();
+      this._applyIndex({ showOverlay: true, broadcast: true, reason: 'mutation' });
+    }
+
+    _toggleSkip(i) {
+      const slide = this._slides[i];
+      if (!slide) return;
+      const on = !slide.hasAttribute('data-deck-skip');
+      if (on) slide.setAttribute('data-deck-skip', '');
+      else slide.removeAttribute('data-deck-skip');
+      if (this._thumbs && this._thumbs[i]) {
+        if (on) this._thumbs[i].thumb.setAttribute('data-skip', '');
+        else this._thumbs[i].thumb.removeAttribute('data-skip');
+      }
+      this._markLastVisible();
+      this._emitDeckChange({ action: on ? 'skip' : 'unskip', from: i, slide });
+      // Re-broadcast so the presenter popup's prev/next thumbnails re-pick
+      // the nearest non-skipped slide without waiting for a nav event.
+      try { window.postMessage({ slideIndexChanged: this._index, deckTotal: this._slides.length, deckSkipped: this._skippedIndices() }, '*'); } catch (e) {}
+    }
+
+    _skippedIndices() {
+      const out = [];
+      for (let i = 0; i < this._slides.length; i++) {
+        if (this._slides[i].hasAttribute('data-deck-skip')) out.push(i);
+      }
+      return out;
+    }
+
+    _moveSlide(i, j) {
+      if (j < 0 || j >= this._slides.length || j === i) return;
+      const slide = this._slides[i];
+      const ref = j < i ? this._slides[j] : this._slides[j].nextSibling;
+      // Track the active slide across the reorder so the same content
+      // stays on screen.
+      const cur = this._index;
+      if (cur === i) this._index = j;
+      else if (i < cur && j >= cur) this._index = cur - 1;
+      else if (i > cur && j <= cur) this._index = cur + 1;
+      this._squelchSlotChange = true;
+      this.insertBefore(slide, ref);
+      this._emitDeckChange({ action: 'move', from: i, to: j, slide });
+      this._collectSlides();
+      this._applyIndex({ showOverlay: false, broadcast: true, reason: 'mutation' });
+    }
+
+    // Public API ------------------------------------------------------------
+
+    /** Current slide index (0-based). */
+    get index() { return this._index; }
+    /** Total slide count. */
+    get length() { return this._slides.length; }
+    /** Programmatically navigate. */
+    goTo(i) { this._go(i, 'api'); }
+    next() { this._advance(1, 'api'); }
+    prev() { this._advance(-1, 'api'); }
+    reset() { this._go(0, 'api'); }
+  }
+
+  if (!customElements.get('deck-stage')) {
+    customElements.define('deck-stage', DeckStage);
+  }
+})();

--- a/public/pitch-deck.html
+++ b/public/pitch-deck.html
@@ -1,0 +1,592 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>LegitReach Pitch Deck</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600&display=swap" rel="stylesheet">
+<style>
+  html, body { margin: 0; padding: 0; background: #000; color: #fff; }
+  body { font-family: 'Inter', sans-serif; -webkit-font-smoothing: antialiased; }
+
+  /* ---------- deck design tokens ---------- */
+  deck-stage {
+    --ds-bg: #000;
+    --ds-fg: #fff;
+    --w: 1920px;
+    --h: 1080px;
+    --pad: 120px;
+    --eyebrow: 26px;
+    --h1: 132px;
+    --h2: 96px;
+    --h3: 64px;
+    --body: 32px;
+    --small: 26px;
+    --rule: rgba(255,255,255,0.10);
+  }
+
+  /* ---------- slide common ---------- */
+  .slide {
+    position: relative;
+    width: 1920px;
+    height: 1080px;
+    padding: var(--pad);
+    box-sizing: border-box;
+    background: #000;
+    color: #fff;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    font-family: 'Inter', sans-serif;
+  }
+  .slide.center { justify-content: center; }
+  .slide .footer {
+    position: absolute;
+    left: var(--pad);
+    right: var(--pad);
+    bottom: 56px;
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 26px; letter-spacing: 0.15em; text-transform: uppercase;
+    color: rgba(255,255,255,0.45);
+  }
+  .slide .header {
+    display: flex; justify-content: space-between; align-items: center;
+    margin-bottom: 64px;
+  }
+  .eyebrow {
+    font-size: var(--eyebrow);
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(255,255,255,0.55);
+  }
+  .brand {
+    font-size: 28px; font-weight: 600; letter-spacing: -0.03em;
+  }
+  h1.deck-title {
+    font-size: var(--h1);
+    font-weight: 300;
+    line-height: 1.02;
+    letter-spacing: -0.05em;
+    margin: 0;
+  }
+  h2.deck-h2 {
+    font-size: var(--h2);
+    font-weight: 300;
+    line-height: 1.05;
+    letter-spacing: -0.045em;
+    margin: 0;
+  }
+  h3.deck-h3 {
+    font-size: var(--h3);
+    font-weight: 300;
+    line-height: 1.1;
+    letter-spacing: -0.035em;
+    margin: 0;
+  }
+  p.body, .body {
+    font-size: var(--body);
+    line-height: 1.45;
+    color: rgba(255,255,255,0.78);
+    margin: 0;
+    max-width: 1300px;
+  }
+  .body.dim { color: rgba(255,255,255,0.55); }
+  .strong-white { color: #fff; }
+  .rule { border-top: 1px solid var(--rule); margin: 56px 0; }
+  .stat { font-size: 200px; font-weight: 200; line-height: 0.95; letter-spacing: -0.06em; }
+  .stat-sub { font-size: var(--eyebrow); letter-spacing: 0.18em; text-transform: uppercase; color: rgba(255,255,255,0.55); margin-top: 20px; }
+
+  .pill {
+    display: inline-flex; align-items: center; gap: 14px;
+    padding: 14px 24px; border: 1px solid rgba(255,255,255,0.22);
+    border-radius: 999px;
+    font-size: var(--small);
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: rgba(255,255,255,0.8);
+  }
+  .pill .dot { width: 8px; height: 8px; border-radius: 999px; background: #86efac; box-shadow: 0 0 10px #86efac; }
+
+  .glass {
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.14);
+    border-radius: 22px;
+    padding: 56px;
+  }
+
+  .row { display: flex; gap: 32px; }
+  .col { flex: 1; min-width: 0; }
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; }
+  .grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 32px; }
+
+  /* ---------- title slide downtown backdrop ---------- */
+  .scene { position: absolute; inset: 0; z-index: 0; overflow: hidden; pointer-events: none; }
+  .scene .bg {
+    position: absolute; inset: 0;
+    background: radial-gradient(ellipse at 50% 85%, #0a0a0a 0%, #000 60%);
+  }
+  .scene .floor {
+    position: absolute; left: 0; right: 0; bottom: 0; height: 55%;
+    background:
+      linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.75) 80%, #000 100%),
+      repeating-linear-gradient(to right, rgba(255,255,255,0.05) 0 1px, transparent 1px 80px),
+      repeating-linear-gradient(to bottom, rgba(255,255,255,0.05) 0 1px, transparent 1px 80px);
+    transform: perspective(1100px) rotateX(64deg);
+    transform-origin: bottom;
+  }
+  .scene svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+  .scene .vignette {
+    position: absolute; inset: 0;
+    background: radial-gradient(ellipse at center, transparent 35%, rgba(0,0,0,0.6) 100%);
+  }
+  .scene-inner { position: relative; z-index: 1; }
+
+  /* hunting dog SVG */
+  .dog-row { display: flex; align-items: center; justify-content: center; gap: 64px; }
+  .dog-row .arrow { font-size: 64px; color: rgba(255,255,255,0.45); }
+
+  .cite {
+    font-size: 18px; letter-spacing: 0.18em; text-transform: uppercase;
+    color: rgba(255,255,255,0.45);
+  }
+
+  /* speedrun mention */
+  .speedrun {
+    font-family: ui-monospace, Menlo, Monaco, monospace;
+    font-size: 18px;
+    letter-spacing: 0.15em;
+    color: rgba(255,255,255,0.45);
+  }
+
+  /* ascii block */
+  .ascii {
+    font-family: ui-monospace, Menlo, Monaco, monospace;
+    font-size: 26px;
+    line-height: 1.45;
+    color: rgba(255,255,255,0.65);
+    white-space: pre;
+  }
+
+  /* page number */
+  .pageno {
+    font-family: ui-monospace, Menlo, Monaco, monospace;
+    font-size: 26px;
+    letter-spacing: 0.1em;
+  }
+</style>
+</head>
+<body>
+<deck-stage width="1920" height="1080" theme="dark" data-om-id="646863b0:8" style="--deck-rail-w: 188px;" data-cc-id="cc-3">
+
+  <!-- 1. Title -->
+  <section class="slide center" data-screen-label="01 Cover" data-om-id="646863b0:9" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="0">
+    <div class="scene" data-om-id="646863b0:10">
+      <div class="bg" data-om-id="646863b0:11"></div>
+      <div class="floor" data-om-id="646863b0:12"></div>
+      <svg viewBox="0 0 1600 900" preserveAspectRatio="xMidYMax slice" data-om-id="646863b0:13">
+        <defs data-om-id="646863b0:14">
+          <linearGradient id="bg-building" x1="0" y1="0" x2="0" y2="1" data-om-id="646863b0:15">
+            <stop offset="0%" stop-color="#161616" data-om-id="646863b0:16"></stop>
+            <stop offset="100%" stop-color="#000" data-om-id="646863b0:17"></stop>
+          </linearGradient>
+        </defs>
+        <g opacity="0.85" data-om-id="646863b0:18">
+          <rect x="-20" y="470" width="110" height="240" fill="url(#bg-building)" data-om-id="646863b0:19"></rect>
+          <rect x="90" y="430" width="80" height="280" fill="url(#bg-building)" data-om-id="646863b0:20"></rect>
+          <rect x="170" y="460" width="130" height="250" fill="url(#bg-building)" data-om-id="646863b0:21"></rect>
+          <rect x="300" y="410" width="90" height="300" fill="url(#bg-building)" data-om-id="646863b0:22"></rect>
+          <rect x="390" y="450" width="110" height="260" fill="url(#bg-building)" data-om-id="646863b0:23"></rect>
+          <rect x="500" y="400" width="80" height="310" fill="url(#bg-building)" data-om-id="646863b0:24"></rect>
+          <rect x="580" y="440" width="120" height="270" fill="url(#bg-building)" data-om-id="646863b0:25"></rect>
+          <rect x="720" y="300" width="180" height="500" fill="url(#bg-building)" data-om-id="646863b0:26"></rect>
+          <rect x="805" y="230" width="10" height="70" fill="url(#bg-building)" data-om-id="646863b0:27"></rect>
+          <rect x="950" y="380" width="150" height="420" fill="url(#bg-building)" data-om-id="646863b0:28"></rect>
+          <rect x="1130" y="420" width="90" height="290" fill="url(#bg-building)" data-om-id="646863b0:29"></rect>
+          <rect x="1220" y="460" width="110" height="250" fill="url(#bg-building)" data-om-id="646863b0:30"></rect>
+          <rect x="1330" y="410" width="100" height="300" fill="url(#bg-building)" data-om-id="646863b0:31"></rect>
+          <rect x="1430" y="440" width="90" height="270" fill="url(#bg-building)" data-om-id="646863b0:32"></rect>
+          <rect x="1520" y="470" width="110" height="240" fill="url(#bg-building)" data-om-id="646863b0:33"></rect>
+        </g>
+        <!-- scatter windows -->
+        <g data-om-id="646863b0:34">
+          <!-- placeholder: tiny dots -->
+        </g>
+        <rect x="0" y="540" width="1600" height="1" fill="#fff" opacity="0.12" data-om-id="646863b0:35"></rect>
+      </svg>
+      <div class="vignette" data-om-id="646863b0:36"></div>
+    </div>
+
+    <div class="scene-inner" style="padding-bottom: 120px;" data-om-id="646863b0:37">
+      <h1 class="deck-title" style="max-width: 1480px;" data-om-id="646863b0:38">World model for online communities.</h1>
+      <p class="body" style="margin-top: 56px; max-width: 1200px;" data-om-id="646863b0:39">A simulator to improve engagement.</p>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:40">
+      <div class="brand" data-om-id="646863b0:41">LegitReach</div>
+      <div class="pageno" data-om-id="646863b0:42">01 / 11</div>
+    </div>
+  </section>
+
+  <!-- 2. Problem -->
+  <section class="slide" data-screen-label="02 Problem" data-om-id="646863b0:43" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="1">
+    <div class="header" data-om-id="646863b0:44">
+      <span class="eyebrow" data-om-id="646863b0:45">02 · The Problem</span>
+      <span class="brand" data-om-id="646863b0:46">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" style="max-width: 1500px;" data-om-id="646863b0:47">
+      AI made content infinite.<br data-om-id="646863b0:48">
+      <span style="color: rgba(255,255,255,0.45)" data-om-id="646863b0:49">Attention stayed finite.</span>
+    </h2>
+
+    <div class="rule" data-om-id="646863b0:50"></div>
+
+    <div style="margin-top: 24px; max-width: 1600px;" data-om-id="646863b0:51">
+      <div class="eyebrow" style="margin-bottom: 28px;" data-om-id="646863b0:52">BRANDS PAIN POINT</div>
+      <h3 class="deck-h3" style="margin-bottom: 28px;" data-om-id="646863b0:53">Community is the answer.<br data-om-id="646863b0:54">Showing up is the cost.</h3>
+      <p class="body" data-om-id="646863b0:55">In our discovery, 35 of 63 lean teams said community outreach is a habit they cannot keep. Paid ads do not compound. CAC keeps rising. The teams that win are not outspending. They are outlistening.</p>
+      <p class="body" style="margin-top: 32px; color: rgba(255,255,255,0.55);" data-om-id="646863b0:56">
+</p>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:57">
+      <div data-om-id="646863b0:58" style="" data-cc-id="cc-2">HUMAN-Online interaction is the most valuable function on the internet.</div>
+      <div class="pageno" data-om-id="646863b0:59">02 / 11</div>
+    </div>
+  </section>
+
+  <!-- 3. Insight -->
+  <section class="slide center" data-screen-label="03 Insight" data-om-id="646863b0:60" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="2">
+    <div class="header" style="position: absolute; top: 120px; left: 120px; right: 120px;" data-om-id="646863b0:61">
+      <span class="eyebrow" data-om-id="646863b0:62">03 · The Insight</span>
+      <span class="brand" data-om-id="646863b0:63">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" style="max-width: 1600px;" data-om-id="646863b0:64">Nobody is modeling the
+online communities
+from first principles.</h2>
+
+    <p class="body" style="margin-top: 56px; max-width: 1400px;" data-om-id="646863b0:65">
+      Most companies use AI to <span class="strong-white" data-om-id="646863b0:66">make more slop</span>.<br data-om-id="646863b0:67">
+      We use AI to <span class="strong-white" data-om-id="646863b0:68">test and predict slop</span> before it ships, at scale.
+    </p>
+
+    <p class="body" style="margin-top: 36px; max-width: 1400px; color: rgba(255,255,255,0.55);" data-om-id="646863b0:69">Online communities are a platform for trading information. A trade of data for engagement as reward.</p>
+
+    <div class="footer" data-om-id="646863b0:70">
+      <div data-om-id="646863b0:71">OBSESSION: DRAW CAPITALISM WITH MATH.</div>
+      <div class="pageno" data-om-id="646863b0:72">03 / 11</div>
+    </div>
+  </section>
+
+  <!-- 4. Solution -->
+  <section class="slide" data-screen-label="04 Solution" data-om-id="646863b0:73" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="3">
+    <div class="header" data-om-id="646863b0:74">
+      <span class="eyebrow" data-om-id="646863b0:75">04 · What we are building</span>
+      <span class="brand" data-om-id="646863b0:76">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" data-om-id="646863b0:77">A simulator for online communities.</h2>
+    <p class="body" style="margin-top: 36px; max-width: 1300px;" data-om-id="646863b0:78">Internally we call it the "Full Power" engine. It rehearses every post/comment/interaction, predicts every outcome, and only ships what works.</p>
+
+    <div class="grid-3" style="margin-top: 80px; align-items: stretch;" data-om-id="646863b0:79">
+      <div class="glass" style="padding: 44px; display: flex; flex-direction: column; gap: 20px;" data-om-id="646863b0:80">
+        <div class="eyebrow" data-om-id="646863b0:81">01 · Listen</div>
+        <h3 class="deck-h3" data-om-id="646863b0:82">Find high-intent threads.</h3>
+        <p class="body" style="font-size: 26px; margin-top: auto;" data-om-id="646863b0:83">Match buyers to your products in real time, across every community that matters.</p>
+      </div>
+      <div class="glass" style="padding: 44px; display: flex; flex-direction: column; gap: 20px;" data-om-id="646863b0:84">
+        <div class="eyebrow" data-om-id="646863b0:85">02 · Rehearse</div>
+        <h3 class="deck-h3" data-om-id="646863b0:86">Predict what lands.</h3>
+        <p class="body" style="font-size: 26px; margin-top: auto;" data-om-id="646863b0:87">Draft, simulate, score before a single character is posted.
+Quality &gt; Quantity</p>
+      </div>
+      <div class="glass" style="padding: 44px; display: flex; flex-direction: column; gap: 20px;" data-om-id="646863b0:88">
+        <div class="eyebrow" data-om-id="646863b0:89">03 · Ship</div>
+        <h3 class="deck-h3" data-om-id="646863b0:90">Human approved</h3>
+        <p class="body" style="font-size: 26px; margin-top: auto;" data-om-id="646863b0:91">You hit approve. The agent posts at human pace. Revenue attributed via UTM.</p>
+      </div>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:92">
+      <div data-om-id="646863b0:93">REHEARSE BEFORE POSTING.</div>
+      <div class="pageno" data-om-id="646863b0:94">04 / 11</div>
+    </div>
+  </section>
+
+  <!-- 5. How it works -->
+  <section class="slide" data-screen-label="05 How" data-om-id="646863b0:95" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="4">
+    <div class="header" data-om-id="646863b0:96">
+      <span class="eyebrow" data-om-id="646863b0:97">05 · How it works</span>
+      <span class="brand" data-om-id="646863b0:98">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" data-om-id="646863b0:99">AI is the hunting dog.<br data-om-id="646863b0:100"><span style="color: rgba(255,255,255,0.45)" data-om-id="646863b0:101">Not the hunter.</span></h2>
+
+    <p class="body" style="margin-top: 56px; max-width: 1500px;" data-om-id="646863b0:102">Our outreach agent runs on a reinforcement learning loop. The agent acts in a sandbox first, learns from feedback, and only ships moves that win.</p>
+
+    <div class="grid-3" style="margin-top: 64px; align-items: stretch;" data-om-id="646863b0:103">
+      <div class="glass" style="padding: 44px; display: flex; flex-direction: column; gap: 18px;" data-om-id="646863b0:104">
+        <div class="eyebrow" data-om-id="646863b0:105">01 · Observe</div>
+        <h3 class="deck-h3" style="font-size: 48px;" data-om-id="646863b0:106">State = a real thread.</h3>
+        <p class="body" style="font-size: 24px; margin-top: auto;" data-om-id="646863b0:107">Subreddit, intent, product fit, your past voice. All vectorized.</p>
+      </div>
+      <div class="glass" style="padding: 44px; display: flex; flex-direction: column; gap: 18px;" data-om-id="646863b0:108">
+        <div class="eyebrow" data-om-id="646863b0:109">02 · Rehearse</div>
+        <h3 class="deck-h3" style="font-size: 48px;" data-om-id="646863b0:110">Many agents, one stage.</h3>
+        <p class="body" style="font-size: 24px; margin-top: auto;" data-om-id="646863b0:111">Authentic community responses. Predicted upvotes, replies, conversion.</p>
+      </div>
+      <div class="glass" style="padding: 44px; display: flex; flex-direction: column; gap: 18px;" data-om-id="646863b0:112">
+        <div class="eyebrow" data-om-id="646863b0:113">03 · Reward</div>
+        <h3 class="deck-h3" style="font-size: 48px;" data-om-id="646863b0:114">Human is the reward signal.</h3>
+        <p class="body" style="font-size: 24px; margin-top: auto;" data-om-id="646863b0:115">You approve. The model learns your tone.</p>
+      </div>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:116">
+      <div data-om-id="646863b0:117">Humans always in the loop. We do not flood. We do not fake.</div>
+      <div class="pageno" data-om-id="646863b0:118">05 / 11</div>
+    </div>
+  </section>
+
+  <!-- 6. Product live -->
+  <section class="slide" data-screen-label="06 Product" data-om-id="646863b0:119" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="5">
+    <div class="header" data-om-id="646863b0:120">
+      <span class="eyebrow" data-om-id="646863b0:121">06 · Product · Live today</span>
+      <span class="brand" data-om-id="646863b0:122">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" data-om-id="646863b0:123">Reddit, mapped to your buyer.</h2>
+    <p class="body" style="margin-top: 36px; max-width: 1300px;" data-om-id="646863b0:124">Live feed of high-intent interaction threads. Agent drafts at superhuman pace. You ship at human pace. Five minutes per day per brand.</p>
+
+    <div class="glass" style="margin-top: 72px; padding: 40px;" data-om-id="646863b0:125">
+      <pre class="ascii" style="margin: 0;" data-om-id="646863b0:126">┌──────────────────────────────  CONTROL ROOM  ──────────────────────────────┐
+│  r/SkincareAddiction · 14m   match 92%      Approve · Skip · Open thread   │
+│  r/30PlusSkinCare    · 38m   match 88%      Approve · Skip · Open thread   │
+│  r/SkincareAddicts   · 3h    match 84%      Approve · Skip · Open thread   │
+│  ─────────────────────────────────────────────────────────────────────     │
+│  AGENT QUEUE   3 to review     · Drafted with your tone · UTM attached     │
+└────────────────────────────────────────────────────────────────────────────┘
+      </pre>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:127">
+      <div data-om-id="646863b0:128"></div>
+      <div class="pageno" data-om-id="646863b0:129">06 / 11</div>
+    </div>
+  </section>
+
+  <!-- 7. Traction -->
+  <section class="slide" data-screen-label="09 Market" data-om-id="646863b0:170" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="8" data-deck-active="">
+    <div class="header" data-om-id="646863b0:171">
+      <span class="eyebrow" data-om-id="646863b0:172">09 · Market</span>
+      <span class="brand" data-om-id="646863b0:173">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" data-om-id="646863b0:174">Three concentric markets.</h2>
+
+    <div class="grid-3" style="margin-top: 96px;" data-om-id="646863b0:175">
+      <div class="glass" data-om-id="646863b0:176">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:177">Wedge · Now</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:178">D2C brands.</h3>
+        <p class="body" style="font-size: 26px;" data-om-id="646863b0:179">$200/seat. Replace one performance marketer with the agent + a human approver.</p>
+      </div>
+      <div class="glass" data-om-id="646863b0:180">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:181">Layer · 12 mo</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:182">Agencies</h3>
+        <p class="body" style="font-size: 26px;" data-om-id="646863b0:183">Multi-brand mode. The "Full Power" engine licensed to teams running ten clients at once.</p>
+      </div>
+      <div class="glass" data-om-id="646863b0:184">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:185">Platform · 24 mo</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:186">World model.</h3>
+        <p class="body" style="margin-top: 0; font-size: 26px;" data-om-id="646863b0:187">API + simulator. Educators teach with it. Researchers query it. Buyers and sellers rehearse on it.</p>
+      </div>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:188">
+      <div data-om-id="646863b0:189">BECOME THE SUBSTRATE FOR ONLINE INTERACTIONS.</div>
+      <div class="pageno" data-om-id="646863b0:190">09 / 11</div>
+    </div>
+  </section><section class="slide" data-screen-label="07 Traction" data-om-id="646863b0:130" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="6" data-cc-id="cc-5">
+    <div class="header" data-om-id="646863b0:131">
+      <span class="eyebrow" data-om-id="646863b0:132">07 · Traction</span>
+      <span class="brand" data-om-id="646863b0:133">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" data-om-id="646863b0:134">Beta users.</h2>
+
+    <div class="grid-3" style="margin-top: 120px;" data-om-id="646863b0:135">
+      <div data-om-id="646863b0:136">
+        <div class="stat" data-om-id="646863b0:137">3</div>
+        <div class="stat-sub" data-om-id="646863b0:138" style="" data-cc-id="cc-6">Paying customers</div>
+      </div>
+      <div data-om-id="646863b0:139">
+        <div class="stat" data-om-id="646863b0:140">$600</div>
+        <div class="stat-sub" data-om-id="646863b0:141">MRR · $200 / seat</div>
+      </div>
+      <div data-om-id="646863b0:142">
+        <div class="stat" data-om-id="646863b0:143">5<span style="font-size: 110px; margin-left: 14px; color: rgba(255,255,255,0.55);" data-om-id="646863b0:144">min</span></div>
+        <div class="stat-sub" data-om-id="646863b0:145">Per day / brand</div>
+      </div>
+    </div>
+
+    <div style="margin-top: 80px;" data-om-id="646863b0:146">
+      <p class="body dim" style="font-size: 26px;" data-om-id="646863b0:147" data-cc-id="cc-4">LOI's signed with two e-commerce agencies managing digital out-reach of multiple D2C brands&nbsp;</p>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:148">
+      <div data-om-id="646863b0:149">BUILT SOLO. VALIDATED SOLO. NOW SCALING TEAM &amp; DISTRIBUTION.</div>
+      <div class="pageno" data-om-id="646863b0:150">07 / 11</div>
+    </div>
+  </section>
+
+  <!-- 8. Why now -->
+  <section class="slide" data-screen-label="08 Why now" data-om-id="646863b0:151" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="7">
+    <div class="header" data-om-id="646863b0:152">
+      <span class="eyebrow" data-om-id="646863b0:153">08 · Why now</span>
+      <span class="brand" data-om-id="646863b0:154">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" data-om-id="646863b0:155" style="" data-cc-id="cc-7">The window is 12 months.</h2>
+
+    <div class="grid-2" style="margin-top: 96px;" data-om-id="646863b0:156">
+      <div class="glass" data-om-id="646863b0:157">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:158">Cost</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:159">Inference fell 90%.</h3>
+        <p class="body" style="font-size: 28px;" data-om-id="646863b0:160">Per-post simulation is finally cheap enough to run on every brand, every day.</p>
+      </div>
+      <div class="glass" data-om-id="646863b0:161">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:162">Behavior</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:163">Buyers fled to communities.</h3>
+        <p class="body" style="font-size: 28px;" data-om-id="646863b0:164">High-intent conversations now happen on Reddit, Discord, niche forums. Not on Meta.</p>
+      </div>
+    </div>
+
+    <p class="body" style="margin-top: 72px; max-width: 1500px;" data-om-id="646863b0:165" data-cc-id="cc-8">
+      Every approved post becomes <span class="strong-white" data-om-id="646863b0:166">labeled training data</span>. The world model compounds. The flywheel can ship in 6 months.
+    </p>
+
+    <div class="footer" data-om-id="646863b0:167">
+      <div data-om-id="646863b0:168">Whoever maps online communities first owns the next decade of commerce.</div>
+      <div class="pageno" data-om-id="646863b0:169">08 / 11</div>
+    </div>
+  </section>
+
+  <!-- 9. Market & vision -->
+  
+
+  <!-- 10. Team -->
+  <section class="slide" data-screen-label="10 Team" data-om-id="646863b0:191" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="9">
+    <div class="header" data-om-id="646863b0:192">
+      <span class="eyebrow" data-om-id="646863b0:193">10 · Team</span>
+      <span class="brand" data-om-id="646863b0:194">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" data-om-id="646863b0:195">Long-term games.<br data-om-id="646863b0:196"><span style="color: rgba(255,255,255,0.45)" data-om-id="646863b0:197">Long-term people.</span></h2>
+
+    <div class="grid-3" style="margin-top: 80px;" data-om-id="646863b0:198">
+      <div class="glass" style="padding: 44px;" data-om-id="646863b0:199">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:200">Founder · CEO</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:201">Manthan Admane</h3>
+        <p class="body" style="font-size: 24px;" data-om-id="646863b0:202">Software developer turned marketing manager at Applied Materials. 2× D2C founder. Owns product, fundraising, and customer development.</p>
+      </div>
+      <div class="glass" style="padding: 44px;" data-om-id="646863b0:203">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:204">Founding Engineer</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:205">Manas Kalangan</h3>
+        <p class="body" style="font-size: 24px;" data-om-id="646863b0:206">Builds the data pipeline, the inference layer, and the Chrome extension that powers the world model.</p>
+      </div>
+      <div class="glass" style="padding: 44px;" data-om-id="646863b0:207">
+        <div class="eyebrow" style="margin-bottom: 24px;" data-om-id="646863b0:208">Research Advisor</div>
+        <h3 class="deck-h3" style="margin-bottom: 16px;" data-om-id="646863b0:209">MIT-WPU Computer Dept.</h3>
+        <p class="body" style="font-size: 24px;" data-om-id="646863b0:210">Co-authored research on AI in marketing. Advises on model architecture and academic validation.</p>
+      </div>
+    </div>
+
+    <div class="footer" data-om-id="646863b0:211">
+      <div data-om-id="646863b0:212">BUILDERS ON A MISSION.</div>
+      <div class="pageno" data-om-id="646863b0:213">10 / 11</div>
+    </div>
+  </section>
+
+  <!-- 11. Ask -->
+  <section class="slide center" data-screen-label="11 Ask" data-om-id="646863b0:214" data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text" data-deck-slide="10" data-deck-last-visible="">
+    <div class="header" style="position: absolute; top: 120px; left: 120px; right: 120px;" data-om-id="646863b0:215">
+      <span class="eyebrow" data-om-id="646863b0:216">11 · The Ask</span>
+      <span class="brand" data-om-id="646863b0:217">LegitReach</span>
+    </div>
+
+    <h2 class="deck-h2" style="margin-bottom: 56px;" data-om-id="646863b0:218">$500k for 10%.</h2>
+
+    <div class="grid-3" style="margin-top: 24px; max-width: 1500px;" data-om-id="646863b0:219">
+      <div data-om-id="646863b0:220">
+        <div class="eyebrow" style="margin-bottom: 18px;" data-om-id="646863b0:221">Instrument</div>
+        <p class="body" style="font-size: 28px;" data-om-id="646863b0:222">YC-style SAFE.</p>
+      </div>
+      <div data-om-id="646863b0:223">
+        <div class="eyebrow" style="margin-bottom: 18px;" data-om-id="646863b0:224">Closing</div>
+        <p class="body" style="font-size: 28px;" data-om-id="646863b0:225">06 / 06 / 2026.</p>
+      </div>
+      <div data-om-id="646863b0:226">
+        <div class="eyebrow" style="margin-bottom: 18px;" data-om-id="646863b0:227">Burn</div>
+        <p class="body" style="font-size: 28px;" data-om-id="646863b0:228">2 engineers, 18 months.</p>
+      </div>
+    </div>
+
+    <div class="rule" style="margin-top: 64px; max-width: 1500px;" data-om-id="646863b0:229"></div>
+
+    <p class="body" style="margin-top: 56px; max-width: 1500px;" data-om-id="646863b0:230">Ship the multi-brand console. API license the engine. Every approved post compounds the model.</p>
+
+    <p class="body" style="margin-top: 56px; font-size: 28px; color: #fff;" data-om-id="646863b0:231">
+      manthan@legitreach.com&nbsp; · &nbsp;legitreach.com
+    </p>
+
+    <div class="footer" data-om-id="646863b0:232">
+      <div data-om-id="646863b0:233"></div>
+      <div class="pageno" data-om-id="646863b0:234">11 / 11</div>
+    </div>
+  </section>
+
+</deck-stage>
+
+<!-- Download / print bar (shown only when opened standalone, hidden inside an iframe + on print) -->
+<div id="deck-toolbar" style="
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+  display: none; gap: 10px; z-index: 1000;
+  background: rgba(0,0,0,0.55);
+  border: 1px solid rgba(255,255,255,0.15);
+  backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
+  padding: 8px; border-radius: 999px;
+  font-family: 'Inter', sans-serif;
+">
+  <a href="index.html#/invest" style="
+    background: transparent; color: #fff;
+    border: 1px solid rgba(255,255,255,0.18);
+    padding: 8px 18px; border-radius: 999px;
+    font-size: 13px; text-decoration: none;
+    transition: background 160ms ease, color 160ms ease;
+  ">← Back to site</a>
+  <button onclick="window.print()" style="
+    background: #fff; color: #000;
+    border: none; padding: 8px 22px; border-radius: 999px;
+    font-size: 13px; font-weight: 500; cursor: pointer;
+    font-family: inherit;
+  ">Download PDF</button>
+</div>
+<script>
+  // Show toolbar only when this page is opened directly (not embedded in an iframe)
+  try {
+    if (window.self === window.top) {
+      document.getElementById('deck-toolbar').style.display = 'flex';
+    }
+  } catch (e) { /* cross-origin = embedded; leave hidden */ }
+</script>
+<style>
+  @media print { #deck-toolbar { display: none !important; } }
+  /* Hide toolbar in presenting mode */
+  deck-stage[presenting] ~ #deck-toolbar { display: none; }
+</style>
+
+<script src="deck-stage.js"></script>
+</body>
+</html>

--- a/src/app/a16z/_agents.tsx
+++ b/src/app/a16z/_agents.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import React from "react";
+
+export type AgentStats = {
+  warmth: number;
+  wit: number;
+  formality: number;
+  brevity: number;
+  assertiveness: number;
+};
+
+export type Agent = {
+  id: string;
+  name: string;
+  tagline: string;
+  vehicle: "tanker" | "coupe" | "drone" | "jet";
+  stats: AgentStats;
+  sample: string;
+  accent: string;
+};
+
+export const AGENTS: Agent[] = [
+  {
+    id: "precision",
+    name: "The Precision",
+    tagline: "Research-grade. Cites sources.",
+    vehicle: "tanker",
+    stats: { warmth: 35, wit: 25, formality: 85, brevity: 60, assertiveness: 70 },
+    sample:
+      '"That claim usually holds, but only above 2% retinol. Source: 2024 Cosmetic Sci. review."',
+    accent: "#cfd8e3",
+  },
+  {
+    id: "classic",
+    name: "The Classic",
+    tagline: "Friendly expert. The default.",
+    vehicle: "coupe",
+    stats: { warmth: 70, wit: 50, formality: 55, brevity: 65, assertiveness: 55 },
+    sample:
+      '"Totally fair concern. Here is what we did in our last batch and why."',
+    accent: "#e9e9e9",
+  },
+  {
+    id: "street",
+    name: "The Street",
+    tagline: "Casual. Comment-section native.",
+    vehicle: "drone",
+    stats: { warmth: 80, wit: 85, formality: 20, brevity: 80, assertiveness: 60 },
+    sample:
+      "\"honestly same. tried it for 3 weeks. didn't love. swapped to X, way better imo.\"",
+    accent: "#f3e5c8",
+  },
+  {
+    id: "turbo",
+    name: "The Turbo",
+    tagline: "High-energy. Founder-style.",
+    vehicle: "jet",
+    stats: { warmth: 65, wit: 70, formality: 40, brevity: 50, assertiveness: 90 },
+    sample:
+      '"We rebuilt the whole formula because of feedback like this. Drop is Friday. AMA."',
+    accent: "#ffd6c2",
+  },
+];
+
+export function AgentSilhouette({
+  accent,
+  active,
+  vehicle = "coupe",
+}: {
+  accent: string;
+  active?: boolean;
+  vehicle?: Agent["vehicle"];
+}) {
+  const stroke = active ? "rgba(255,255,255,0.7)" : "rgba(255,255,255,0.25)";
+  const subtle = "rgba(255,255,255,0.15)";
+  const wheelStroke = "rgba(255,255,255,0.3)";
+  const gradId = `lr-bodyG-${vehicle}-${accent.replace(/[^a-z0-9]/gi, "")}`;
+  const fill = `url(#${gradId})`;
+  const glass = `url(#${gradId}-glass)`;
+  const accentOp = active ? 0.9 : 0.5;
+
+  return (
+    <svg
+      viewBox="0 0 200 70"
+      style={{ width: "100%", height: "auto", display: "block" }}
+    >
+      <defs>
+        <linearGradient id={gradId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#1c1c1c" />
+          <stop offset="100%" stopColor="#070707" />
+        </linearGradient>
+        <linearGradient id={`${gradId}-glass`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#000" />
+          <stop offset="100%" stopColor="#0a0a0a" />
+        </linearGradient>
+      </defs>
+      <ellipse cx="100" cy="64" rx="80" ry="3" fill="#000" opacity="0.6" />
+
+      {vehicle === "tanker" && (
+        <g>
+          <rect x="10" y="30" width="110" height="28" rx="6" fill={fill} stroke={stroke} strokeWidth="1" />
+          <line x1="45" y1="30" x2="45" y2="58" stroke={subtle} strokeWidth="0.8" />
+          <line x1="80" y1="30" x2="80" y2="58" stroke={subtle} strokeWidth="0.8" />
+          <rect x="55" y="24" width="14" height="6" rx="1.5" fill={fill} stroke={stroke} strokeWidth="0.8" />
+          <path d="M125,58 L125,38 L150,32 L168,42 L186,42 L186,58 Z" fill={fill} stroke={stroke} strokeWidth="1" />
+          <path d="M152,40 L165,42 L165,48 L152,48 Z" fill={glass} stroke={subtle} strokeWidth="0.6" />
+          <rect x="10" y="46" width="110" height="1.5" fill={accent} opacity={accentOp} />
+          {[28, 50, 95, 138, 172].map((cx, i) => (
+            <g key={i}>
+              <circle cx={cx} cy="60" r="6" fill="#000" stroke={wheelStroke} strokeWidth="1" />
+              <circle cx={cx} cy="60" r="2" fill={accent} opacity="0.7" />
+            </g>
+          ))}
+        </g>
+      )}
+
+      {vehicle === "coupe" && (
+        <g>
+          <path
+            d="M10,55 L30,40 L65,28 L130,28 L165,40 L190,55 L190,60 L10,60 Z"
+            fill={fill}
+            stroke={stroke}
+            strokeWidth="1"
+          />
+          <path d="M45,40 L70,32 L125,32 L150,40 Z" fill={glass} stroke={subtle} strokeWidth="0.7" />
+          <line x1="30" y1="50" x2="170" y2="50" stroke={subtle} strokeWidth="0.6" />
+          <rect x="30" y="48" width="140" height="1.5" fill={accent} opacity={accentOp} />
+          <circle cx="185" cy="50" r="1.6" fill={accent} opacity="0.8" />
+          <circle cx="15" cy="50" r="1.6" fill="#fff" opacity="0.4" />
+          <circle cx="50" cy="60" r="8" fill="#000" stroke={wheelStroke} strokeWidth="1" />
+          <circle cx="150" cy="60" r="8" fill="#000" stroke={wheelStroke} strokeWidth="1" />
+          <circle cx="50" cy="60" r="3" fill={accent} opacity="0.7" />
+          <circle cx="150" cy="60" r="3" fill={accent} opacity="0.7" />
+        </g>
+      )}
+
+      {vehicle === "drone" && (
+        <g>
+          <line x1="40" y1="30" x2="160" y2="58" stroke={stroke} strokeWidth="3" strokeLinecap="round" />
+          <line x1="40" y1="58" x2="160" y2="30" stroke={stroke} strokeWidth="3" strokeLinecap="round" />
+          <rect x="82" y="36" width="36" height="16" rx="4" fill={fill} stroke={stroke} strokeWidth="1" />
+          <circle cx="100" cy="54" r="3" fill="#000" stroke={subtle} strokeWidth="0.8" />
+          <circle cx="100" cy="54" r="1.2" fill={accent} opacity="0.9" />
+          {(
+            [
+              [40, 30],
+              [160, 30],
+              [40, 58],
+              [160, 58],
+            ] as Array<[number, number]>
+          ).map(([cx, cy], i) => (
+            <g key={i}>
+              <ellipse cx={cx} cy={cy} rx="14" ry="2" fill="#fff" opacity={active ? 0.18 : 0.1} />
+              <ellipse cx={cx} cy={cy} rx="2" ry="14" fill="#fff" opacity={active ? 0.18 : 0.1} />
+              <circle cx={cx} cy={cy} r="3" fill={fill} stroke={stroke} strokeWidth="0.8" />
+              <circle cx={cx} cy={cy} r="1" fill={accent} opacity={accentOp} />
+            </g>
+          ))}
+          <rect x="90" y="40" width="20" height="1.5" fill={accent} opacity={accentOp} />
+        </g>
+      )}
+
+      {vehicle === "jet" && (
+        <g>
+          <rect x="4" y="42" width="22" height="3" rx="1.5" fill={accent} opacity={active ? 0.7 : 0.35} />
+          <rect x="-2" y="43.5" width="14" height="1" fill="#fff" opacity={active ? 0.6 : 0.25} />
+          <path d="M20,42 L150,38 L188,43.5 L150,49 L20,46 Z" fill={fill} stroke={stroke} strokeWidth="1" />
+          <path d="M70,46 L130,46 L110,58 L60,58 Z" fill={fill} stroke={stroke} strokeWidth="1" />
+          <path d="M80,42 L120,42 L138,30 L100,30 Z" fill={fill} stroke={stroke} strokeWidth="1" opacity="0.9" />
+          <path d="M40,42 L60,28 L72,42 Z" fill={fill} stroke={stroke} strokeWidth="1" />
+          <path d="M130,40 L155,40.5 L168,43.5 L155,46 L130,45 Z" fill={glass} stroke={subtle} strokeWidth="0.6" />
+          <line x1="100" y1="30" x2="138" y2="30" stroke={accent} strokeWidth="1.2" opacity={accentOp} />
+          <line x1="60" y1="58" x2="110" y2="58" stroke={accent} strokeWidth="1.2" opacity={accentOp} />
+          <circle cx="186" cy="43.5" r="1.4" fill={accent} opacity="0.9" />
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/src/app/a16z/_chrome.tsx
+++ b/src/app/a16z/_chrome.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+
+export function TopBar({
+  step,
+  total,
+  onBack,
+}: {
+  step: number;
+  total: number;
+  onBack: () => void;
+}) {
+  const onDashboard = step > total;
+  return (
+    <div
+      className="px-6 md:px-12 lg:px-16 pt-6"
+      style={{ position: "fixed", top: 0, left: 0, right: 0, zIndex: 50 }}
+    >
+      <div className="liquid-glass rounded-xl px-4 py-3 flex items-center justify-between">
+        <div className="flex items-center" style={{ gap: "1rem" }}>
+          <Link href="/" className="text-xl font-semibold" style={{ letterSpacing: "-0.03em" }}>
+            LegitReach
+          </Link>
+          <span style={{ color: "rgba(255,255,255,0.25)" }}>/</span>
+          <span className="text-xs uppercase tracking-widest" style={{ color: "#d1d5db" }}>
+            CREATE AUTHENTIC DIGITAL PERSONAS
+          </span>
+        </div>
+        {!onDashboard && <Steps step={step} total={total} />}
+        <div className="flex items-center" style={{ gap: "0.75rem" }}>
+          {step > 1 && !onDashboard && (
+            <button
+              onClick={onBack}
+              className="text-sm"
+              style={{
+                background: "transparent",
+                color: "#d1d5db",
+                transition: "color 200ms ease",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              Back
+            </button>
+          )}
+          <Link
+            href={onDashboard ? "/beta" : "/"}
+            className="text-sm"
+            style={{ color: "#d1d5db", transition: "color 200ms ease" }}
+          >
+            {onDashboard ? "Sign out" : "Exit"}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Steps({ step, total }: { step: number; total: number }) {
+  return (
+    <div className="hidden md:flex items-center" style={{ gap: "0.75rem" }}>
+      {Array.from({ length: total }).map((_, i) => {
+        const n = i + 1;
+        const done = n < step;
+        const active = n === step;
+        return (
+          <div key={i} className="flex items-center" style={{ gap: "0.5rem" }}>
+            <div
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: 999,
+                border: "1px solid rgba(255,255,255,0.25)",
+                background: done ? "#fff" : active ? "rgba(255,255,255,0.12)" : "transparent",
+                color: done ? "#000" : active ? "#fff" : "rgba(255,255,255,0.5)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 11,
+                fontWeight: 500,
+              }}
+            >
+              {done ? "✓" : n}
+            </div>
+            {i < total - 1 && (
+              <div
+                style={{
+                  width: 28,
+                  height: 1,
+                  background: done
+                    ? "rgba(255,255,255,0.5)"
+                    : "rgba(255,255,255,0.15)",
+                }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function Modal({
+  children,
+  title,
+  onClose,
+}: {
+  children: React.ReactNode;
+  title: string;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 100,
+        background: "rgba(0,0,0,0.65)",
+        backdropFilter: "blur(6px)",
+        WebkitBackdropFilter: "blur(6px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "1.5rem",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="liquid-glass rounded-2xl p-8"
+        style={{
+          border: "1px solid rgba(255,255,255,0.2)",
+          width: "100%",
+          maxWidth: "36rem",
+        }}
+      >
+        <div className="flex items-center justify-between mb-6">
+          <h3 className="text-xl font-normal" style={{ letterSpacing: "-0.02em" }}>
+            {title}
+          </h3>
+          <button
+            onClick={onClose}
+            style={{
+              background: "transparent",
+              fontSize: 20,
+              lineHeight: 1,
+              border: "none",
+              color: "#9ca3af",
+              cursor: "pointer",
+            }}
+          >
+            ×
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function BackgroundIndexer({ compact = false }: { compact?: boolean }) {
+  const [n, setN] = useState(3208451);
+  useEffect(() => {
+    const id = setInterval(
+      () => setN((v) => v + Math.floor(Math.random() * 60) + 10),
+      700
+    );
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <div
+      className="flex items-center liquid-glass rounded-full"
+      style={{
+        gap: "0.55rem",
+        padding: "0.35rem 0.85rem",
+        border: "1px solid rgba(255,255,255,0.12)",
+      }}
+    >
+      <span
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: 999,
+          background: "#a5f3fc",
+          boxShadow: "0 0 8px #a5f3fc",
+          animation: "lr-pulse-soft 1.4s ease-in-out infinite",
+        }}
+      />
+      <span
+        className="text-xs uppercase tracking-widest"
+        style={{ color: "#cffafe", letterSpacing: "0.15em" }}
+      >
+        Indexing
+      </span>
+      {!compact && (
+        <span
+          className="text-xs"
+          style={{
+            color: "#d1d5db",
+            fontFamily: "ui-monospace, Menlo, Monaco, monospace",
+            letterSpacing: "0.02em",
+          }}
+        >
+          {n.toLocaleString()} posts seen
+        </span>
+      )}
+    </div>
+  );
+}
+
+function SkeletonRow({ height = 78 }: { height?: number }) {
+  return (
+    <div
+      className="rounded-xl"
+      style={{
+        height,
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.06)",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background:
+            "linear-gradient(90deg, transparent, rgba(255,255,255,0.06), transparent)",
+          animation: "lr-shimmer 1.6s linear infinite",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 14,
+          left: 16,
+          right: 16,
+          height: 8,
+          background: "rgba(255,255,255,0.05)",
+          borderRadius: 4,
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          top: 32,
+          left: 16,
+          width: "70%",
+          height: 10,
+          background: "rgba(255,255,255,0.04)",
+          borderRadius: 4,
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          bottom: 14,
+          left: 16,
+          width: "40%",
+          height: 6,
+          background: "rgba(255,255,255,0.04)",
+          borderRadius: 4,
+        }}
+      />
+    </div>
+  );
+}
+
+export function PanelLoading({
+  label,
+  rows = 3,
+}: {
+  label: string;
+  rows?: number;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+      <div
+        className="flex items-center text-xs"
+        style={{ gap: "0.5rem", marginBottom: "0.25rem", color: "#9ca3af" }}
+      >
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: 999,
+            background: "#a5f3fc",
+            boxShadow: "0 0 6px #a5f3fc",
+            animation: "lr-pulse-soft 1.4s ease-in-out infinite",
+          }}
+        />
+        <span>{label}</span>
+      </div>
+      {Array.from({ length: rows }).map((_, i) => (
+        <SkeletonRow key={i} />
+      ))}
+    </div>
+  );
+}
+
+export function LockIcon() {
+  return (
+    <svg
+      width="28"
+      height="28"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#fff"
+      strokeWidth="1.5"
+      opacity="0.85"
+    >
+      <rect x="4" y="11" width="16" height="10" rx="2" />
+      <path d="M8 11V8a4 4 0 0 1 8 0v3" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/app/a16z/_dashboard.tsx
+++ b/src/app/a16z/_dashboard.tsx
@@ -1,0 +1,1284 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { FadeIn, AnimatedHeading } from "@/components/lr-design/visuals";
+import {
+  BackgroundIndexer,
+  Modal,
+  PanelLoading,
+  LockIcon,
+} from "./_chrome";
+import { AGENTS, AgentSilhouette } from "./_agents";
+
+type FeedPost = {
+  sub: string;
+  title: string;
+  age: string;
+  up: number;
+  comments: number;
+  intent: "high" | "medium";
+  match: number;
+};
+
+const FEED_POSTS: FeedPost[] = [
+  { sub: "r/SkincareAddiction", title: "Anyone else find retinol harsh in winter? Looking for a gentle nightly alt.", age: "14m", up: 132, comments: 47, intent: "high", match: 92 },
+  { sub: "r/30PlusSkinCare", title: "Best vitamin C serum that does not pill under sunscreen?", age: "38m", up: 84, comments: 21, intent: "high", match: 88 },
+  { sub: "r/AsianBeauty", title: "Niacinamide and copper peptides, actually a problem?", age: "1h", up: 210, comments: 96, intent: "medium", match: 71 },
+  { sub: "r/EntrepreneurRideAlong", title: "Anyone here scaled a skincare DTC past $1M without paid ads?", age: "2h", up: 64, comments: 33, intent: "medium", match: 58 },
+  { sub: "r/SkincareAddicts", title: "Sensitive skin routine for someone in Phoenix, heat is killing me", age: "3h", up: 41, comments: 18, intent: "high", match: 84 },
+];
+
+type RedditItem = {
+  subreddit: string;
+  body: string;
+  created_utc: number;
+  url: string;
+};
+
+const REDDIT_HISTORY: RedditItem[] = [
+  { subreddit: "nagpur", body: "24 hour update:\n\nI got more responses than expected. This is great as community effort for the project would be crucial.\n\nWe are live: www.orng.shop\n\nOn the website:\nA. One pager to what the project currently looks like\nB. Join button adds you to a Whatsapp group.\n\nThanks for everyone who expressed support and interest. Cheers 🍊", created_utc: 1776075703, url: "https://www.reddit.com/r/nagpur/comments/1sja8e2/help_me_make_nagpur_global/ofwuy3g/" },
+  { subreddit: "SideProject", body: "www.LegitReach.com", created_utc: 1774422193, url: "https://www.reddit.com/r/SideProject/comments/1s2nja9/drop_your_project_link_ill_write_you_a_oneliner/occmc82/" },
+  { subreddit: "gohighlevel", body: "What's a2p in this context?", created_utc: 1773808392, url: "https://www.reddit.com/r/gohighlevel/comments/1rwoy5q/i_need_help_with_a2p_application/ob2bz3o/" },
+  { subreddit: "redditdev", body: "HOW TO GET THE APIS?", created_utc: 1773758675, url: "https://www.reddit.com/r/redditdev/comments/1rw6oqa/so_i_just_submitted_a_request_for_api_access/oaxtaod/" },
+  { subreddit: "ClaudeAI", body: "Trying to do everything :!", created_utc: 1773741904, url: "https://www.reddit.com/r/ClaudeAI/comments/1rvu2lu/what_have_you_done_with_claude/oawkrfl/" },
+  { subreddit: "ecommerce", body: "Keep it simple.\n\nIf you're certain you're a better price than Amazon and Amazon has a similar product, you should get a winnable CAC.", created_utc: 1773737645, url: "https://www.reddit.com/r/ecommerce/comments/1rvh0gp/what_am_i_doing_wrong/oawda7l/" },
+  { subreddit: "saasbuild", body: "Slide into your ICPs DM on Reddit.\nUnlock legit conversations and insights. Get 10 paid users.\nwww.LegitReach.com", created_utc: 1773736571, url: "https://www.reddit.com/r/saasbuild/comments/1rvopqi/can_you_explain_your_startup_in_one_sentence/oawbgpi/" },
+  { subreddit: "FacebookAds", body: "Stop blaming iOS updates.\n\nYour CAC is high because you're selling to people who didn't ask for your product. Meanwhile there are Reddit threads full of your exact ICP describing their problems in their own words; for free.\n\nThe brands winning right now aren't outspending you, they're outlistening you. (Especially with superlistening AI capabilities)", created_utc: 1773734283, url: "https://www.reddit.com/r/FacebookAds/comments/1qh4cwq/anyone_else_seeing_terrible_ios_performance_after/oaw7n94/" },
+  { subreddit: "FacebookAds", body: "Reddit threads are worth more than your entire Meta ad budget. People are literally typing \"I wish someone made X\" and you're spending $50/day on carousel ads hoping the algorithm cares.\n\nI started scanning Reddit daily for my brand and found more actionable product ideas in a week than 6 months of ads data.", created_utc: 1773734199, url: "https://www.reddit.com/r/FacebookAds/comments/1r4l6fa/my_sales_have_dropped_by_80_in_the_last_3_days_is/oaw7i4q/" },
+  { subreddit: "ecommerce", body: "Ok boss, edits incoming.", created_utc: 1773734044, url: "https://www.reddit.com/r/ecommerce/comments/1rvzfqr/i_spent_40_hours_reading_reddit_threads_about/oaw78vj/" },
+];
+
+function formatRedditDate(unix: number) {
+  const d = new Date(unix * 1000);
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+const STATS = [
+  { label: "Outreach actions", value: "84" },
+  { label: "Interactions achieved", value: "12.4k" },
+];
+
+type QueueItem = {
+  sub: string;
+  summary: string;
+  action: string;
+  status: "draft" | "review" | "approved" | "skipped";
+  confidence: number;
+};
+
+const QUEUE: QueueItem[] = [
+  { sub: "r/SkincareAddiction", summary: "Asks for a gentle winter retinol alternative.", action: "Reply with bakuchiol context + your Calm Serum link via UTM.", status: "draft", confidence: 0.92 },
+  { sub: "r/30PlusSkinCare", summary: "Wants vitamin C that does not pill under SPF.", action: "Reply citing 10% ascorbic vs ascorbyl glucoside, mention your Daylight C.", status: "review", confidence: 0.88 },
+  { sub: "r/SkincareAddicts", summary: "Phoenix heat, sensitive skin routine.", action: "Share a 4-step gentle routine; soft mention of your Gel Cleanser.", status: "draft", confidence: 0.84 },
+];
+
+export function Step4Dashboard({
+  agentId,
+  setAgentId,
+}: {
+  agentId: string;
+  setAgentId: (id: string) => void;
+}) {
+  const [queue, setQueue] = useState<QueueItem[]>(QUEUE);
+  const [feedLoaded, setFeedLoaded] = useState(false);
+  const [queueLoaded, setQueueLoaded] = useState(false);
+  const [showPayment, setShowPayment] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [tokens, setTokens] = useState(87);
+  const [redditUsername, setRedditUsername] = useState("");
+  const [showMoreFeed, setShowMoreFeed] = useState(false);
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setFeedLoaded(true), 1600);
+    const t2 = setTimeout(() => setQueueLoaded(true), 2400);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, []);
+
+  const remainingToReview = queue.filter(
+    (q) => q.status === "draft" || q.status === "review"
+  ).length;
+
+  return (
+    <div
+      className="px-6 md:px-12 lg:px-16"
+      style={{ paddingTop: "7.5rem", paddingBottom: "4rem" }}
+    >
+      <div className="max-w-7xl mx-auto">
+        <div
+          className="flex items-center justify-between mb-4"
+          style={{ flexWrap: "wrap", gap: "0.75rem" }}
+        >
+          <FadeIn duration={700}>
+            <div
+              className="text-xs uppercase tracking-widest"
+              style={{ color: "#9ca3af" }}
+            >
+              YOUR CONTROL ROOM
+            </div>
+          </FadeIn>
+          <FadeIn delay={200} duration={700}>
+            <BackgroundIndexer />
+          </FadeIn>
+        </div>
+        <div
+          className="flex flex-wrap items-end justify-between"
+          style={{ gap: "1rem", marginBottom: "2rem" }}
+        >
+          <AnimatedHeading
+            text="Your online stats"
+            className="text-3xl md:text-4xl lg:text-5xl font-normal"
+          />
+        </div>
+
+        <FadeIn delay={300} duration={700}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(2, minmax(0,1fr))",
+              gap: "1rem",
+              marginBottom: "2rem",
+            }}
+          >
+            {STATS.map((s, i) => (
+              <div
+                key={i}
+                className="liquid-glass rounded-xl"
+                style={{
+                  border: "1px solid rgba(255,255,255,0.15)",
+                  padding: "1.5rem 1.75rem",
+                }}
+              >
+                <div
+                  className="text-xs uppercase tracking-widest mb-3"
+                  style={{ color: "#9ca3af" }}
+                >
+                  {s.label}
+                </div>
+                <div
+                  style={{
+                    fontSize: "3rem",
+                    letterSpacing: "-0.04em",
+                    lineHeight: 1,
+                    fontWeight: 300,
+                  }}
+                >
+                  {s.value}
+                </div>
+              </div>
+            ))}
+          </div>
+        </FadeIn>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(2, minmax(0,1fr))",
+            gap: "1.5rem",
+            alignItems: "stretch",
+          }}
+        >
+          {/* Live feed */}
+          <FadeIn delay={400} duration={700} style={{ display: "flex" }}>
+            <div
+              className="liquid-glass rounded-2xl p-6"
+              style={{
+                border: "1px solid rgba(255,255,255,0.18)",
+                display: "flex",
+                flexDirection: "column",
+                width: "100%",
+              }}
+            >
+              <div className="flex items-center justify-between mb-5">
+                <div>
+                  <div
+                    className="text-xs uppercase tracking-widest mb-1"
+                    style={{ color: "#9ca3af" }}
+                  >
+                    Live feed
+                  </div>
+                  <div className="text-lg font-medium">
+                    Conversations matching your audience
+                  </div>
+                </div>
+                <div className="text-xs" style={{ color: "#9ca3af" }}>
+                  {feedLoaded ? "refreshed 12s ago" : "scanning…"}
+                </div>
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+                {feedLoaded ? (
+                  (showMoreFeed ? FEED_POSTS : FEED_POSTS.slice(0, 2)).map(
+                    (p, i) => <FeedRow key={i} post={p} />
+                  )
+                ) : (
+                  <PanelLoading
+                    label="Scanning communities for matches…"
+                    rows={2}
+                  />
+                )}
+              </div>
+              {feedLoaded && FEED_POSTS.length > 2 && (
+                <div style={{ marginTop: "auto", paddingTop: "1.25rem" }}>
+                  <button
+                    onClick={() => setShowMoreFeed((v) => !v)}
+                    style={{
+                      background: "transparent",
+                      color: "#d1d5db",
+                      fontSize: 13,
+                      textDecoration: "underline",
+                      textUnderlineOffset: 4,
+                      padding: 0,
+                      border: "none",
+                      cursor: "pointer",
+                    }}
+                  >
+                    {showMoreFeed
+                      ? "Show fewer matches ↑"
+                      : `Show ${FEED_POSTS.length - 2} more matches →`}
+                  </button>
+                </div>
+              )}
+            </div>
+          </FadeIn>
+
+          {/* Agent action queue */}
+          <FadeIn delay={500} duration={700} style={{ display: "flex" }}>
+            <div
+              className="liquid-glass rounded-2xl p-6"
+              style={{
+                border: "1px solid rgba(255,255,255,0.18)",
+                display: "flex",
+                flexDirection: "column",
+                width: "100%",
+              }}
+            >
+              <div className="flex items-center justify-between mb-5">
+                <div>
+                  <div
+                    className="text-xs uppercase tracking-widest mb-1"
+                    style={{ color: "#9ca3af" }}
+                  >
+                    Agent actions
+                  </div>
+                  <div className="text-lg font-medium">
+                    Outreach drafts awaiting you
+                  </div>
+                </div>
+                <div
+                  className="text-xs"
+                  style={{ color: queueLoaded ? "#fde68a" : "#cbd5e1" }}
+                >
+                  {queueLoaded ? `${remainingToReview} to review` : "drafting…"}
+                </div>
+              </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+                {queueLoaded ? (
+                  queue.slice(0, 2).map((q, i) => (
+                    <ActionRow
+                      key={i}
+                      q={q}
+                      onApprove={() =>
+                        setQueue((qs) =>
+                          qs.map((x, j) =>
+                            j === i ? { ...x, status: "approved" } : x
+                          )
+                        )
+                      }
+                      onSkip={() =>
+                        setQueue((qs) =>
+                          qs.map((x, j) =>
+                            j === i ? { ...x, status: "skipped" } : x
+                          )
+                        )
+                      }
+                    />
+                  ))
+                ) : (
+                  <PanelLoading label="Composing on-brand drafts…" rows={2} />
+                )}
+              </div>
+              {queueLoaded && queue.length > 2 && (
+                <div style={{ marginTop: "auto", paddingTop: "1.25rem" }}>
+                  <button
+                    style={{
+                      background: "transparent",
+                      color: "#d1d5db",
+                      fontSize: 13,
+                      textDecoration: "underline",
+                      textUnderlineOffset: 4,
+                      padding: 0,
+                      border: "none",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Show {queue.length - 2} more drafts →
+                  </button>
+                </div>
+              )}
+            </div>
+          </FadeIn>
+        </div>
+
+        {/* Reddit history */}
+        <FadeIn delay={600} duration={700}>
+          <RedditHistoryPanel
+            username={redditUsername}
+            onConnect={() => setShowSettings(true)}
+          />
+        </FadeIn>
+
+        <FadeIn delay={700} duration={700}>
+          <div
+            className="mt-12 flex flex-wrap items-center justify-between"
+            style={{ gap: "1rem" }}
+          >
+            <div className="text-sm" style={{ color: "#9ca3af" }}>
+              Demo workflow completed. You can access the beta by clicking{" "}
+              <Link
+                href="/beta"
+                style={{
+                  color: "#fff",
+                  textDecoration: "underline",
+                  textUnderlineOffset: 3,
+                }}
+              >
+                here
+              </Link>
+              .
+            </div>
+            <div className="flex flex-wrap" style={{ gap: "0.75rem" }}>
+              <button
+                onClick={() => setShowPayment(true)}
+                className="lr-btn-ghost liquid-glass"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "0.5rem",
+                }}
+              >
+                <span
+                  style={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: 999,
+                    background: tokens > 20 ? "#86efac" : "#fca5a5",
+                    boxShadow: `0 0 6px ${tokens > 20 ? "#86efac" : "#fca5a5"}`,
+                  }}
+                />
+                <span>
+                  Actions remaining:{" "}
+                  <strong style={{ fontWeight: 600 }}>{tokens}</strong>
+                </span>
+              </button>
+              <button
+                onClick={() => setShowSettings(true)}
+                className="lr-btn-primary"
+              >
+                Settings
+              </button>
+            </div>
+          </div>
+        </FadeIn>
+      </div>
+
+      {showPayment && (
+        <PaymentModal
+          currentTokens={tokens}
+          onClose={() => setShowPayment(false)}
+          onTopUp={(amount) => {
+            setTokens((t) => t + amount);
+            setShowPayment(false);
+          }}
+        />
+      )}
+      {showSettings && (
+        <SettingsModal
+          username={redditUsername}
+          setUsername={setRedditUsername}
+          agentId={agentId}
+          setAgentId={setAgentId}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function FeedRow({ post }: { post: FeedPost }) {
+  const intentColor = post.intent === "high" ? "#86efac" : "#fde68a";
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs" style={{ color: "#9ca3af" }}>
+          {post.sub} · {post.age}
+        </div>
+        <div className="flex items-center" style={{ gap: "0.5rem" }}>
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: intentColor,
+              boxShadow: `0 0 6px ${intentColor}`,
+            }}
+          />
+          <span className="text-xs" style={{ color: intentColor }}>
+            {post.intent} intent
+          </span>
+        </div>
+      </div>
+      <div
+        className="text-sm leading-snug mb-3"
+        style={{ fontWeight: 500, color: "#f3f4f6" }}
+      >
+        {post.title}
+      </div>
+      <div className="flex items-center justify-between">
+        <div
+          className="text-xs flex items-center"
+          style={{ gap: "0.85rem", color: "#9ca3af" }}
+        >
+          <span className="flex items-center" style={{ gap: "0.3rem" }}>
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 10 10"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              style={{ opacity: 0.7 }}
+            >
+              <path d="M5 1.5 L1.5 5.5 M5 1.5 L8.5 5.5 M5 1.5 L5 8.5" />
+            </svg>
+            <span>{post.up}</span>
+          </span>
+          <span className="flex items-center" style={{ gap: "0.3rem" }}>
+            <svg
+              width="11"
+              height="11"
+              viewBox="0 0 12 12"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinejoin="round"
+              style={{ opacity: 0.7 }}
+            >
+              <path d="M2 3.2 a1.2 1.2 0 0 1 1.2 -1.2 h5.6 a1.2 1.2 0 0 1 1.2 1.2 v3.6 a1.2 1.2 0 0 1 -1.2 1.2 h-3.4 l-2.4 1.8 v-1.8 h-0.0 a1.2 1.2 0 0 1 -1.2 -1.2 z" />
+            </svg>
+            <span>{post.comments}</span>
+          </span>
+        </div>
+        <div className="text-xs" style={{ color: "#fff" }}>
+          match {post.match}%
+        </div>
+      </div>
+      <div
+        style={{
+          marginTop: 8,
+          height: 3,
+          background: "rgba(255,255,255,0.08)",
+          borderRadius: 999,
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${post.match}%`,
+            height: "100%",
+            background: "#fff",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ActionRow({
+  q,
+  onApprove,
+  onSkip,
+}: {
+  q: QueueItem;
+  onApprove: () => void;
+  onSkip: () => void;
+}) {
+  const isDone = q.status === "approved" || q.status === "skipped";
+  const badgeColor =
+    q.status === "approved"
+      ? "#86efac"
+      : q.status === "skipped"
+      ? "#fca5a5"
+      : q.status === "review"
+      ? "#fde68a"
+      : "#cbd5e1";
+  const badgeLabel: Record<QueueItem["status"], string> = {
+    approved: "queued to post",
+    skipped: "skipped",
+    review: "needs review",
+    draft: "drafted",
+  };
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        opacity: isDone ? 0.7 : 1,
+        transition: "opacity 200ms ease",
+      }}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-xs" style={{ color: "#9ca3af" }}>
+          {q.sub}
+        </div>
+        <div className="flex items-center" style={{ gap: "0.5rem" }}>
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: badgeColor,
+            }}
+          />
+          <span className="text-xs" style={{ color: badgeColor }}>
+            {badgeLabel[q.status]}
+          </span>
+        </div>
+      </div>
+      <div
+        className="text-sm leading-snug mb-1"
+        style={{ color: "#f3f4f6" }}
+      >
+        {q.summary}
+      </div>
+      <div
+        className="text-xs mb-3"
+        style={{ fontStyle: "italic", color: "#9ca3af" }}
+      >
+        Plan: {q.action}
+      </div>
+      <div className="flex items-center justify-between">
+        <div className="text-xs" style={{ color: "#9ca3af" }}>
+          Confidence {(q.confidence * 100).toFixed(0)}%
+        </div>
+        {!isDone && (
+          <div className="flex" style={{ gap: "0.5rem" }}>
+            <button
+              onClick={onSkip}
+              style={{
+                background: "transparent",
+                color: "#d1d5db",
+                border: "1px solid rgba(255,255,255,0.2)",
+                borderRadius: 8,
+                padding: "0.35rem 0.9rem",
+                fontSize: 13,
+                cursor: "pointer",
+              }}
+            >
+              Skip
+            </button>
+            <button
+              onClick={onApprove}
+              style={{
+                background: "#fff",
+                color: "#000",
+                border: "none",
+                borderRadius: 8,
+                padding: "0.35rem 0.9rem",
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: "pointer",
+              }}
+            >
+              Approve
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RedditHistoryPanel({
+  username,
+  onConnect,
+}: {
+  username: string;
+  onConnect: () => void;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const [shown, setShown] = useState(4);
+
+  useEffect(() => {
+    if (!username) return;
+    const t = setTimeout(() => setRevealed(true), 900);
+    return () => clearTimeout(t);
+  }, [username]);
+
+  const locked = !username;
+  const items = REDDIT_HISTORY;
+
+  return (
+    <div
+      className="liquid-glass rounded-2xl"
+      style={{
+        border: "1px solid rgba(255,255,255,0.18)",
+        marginTop: "1.5rem",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        className="flex items-center justify-between"
+        style={{
+          padding: "1.25rem 1.5rem",
+          borderBottom: "1px solid rgba(255,255,255,0.08)",
+        }}
+      >
+        <div>
+          <div
+            className="text-xs uppercase tracking-widest mb-1"
+            style={{ color: "#9ca3af" }}
+          >
+            Your Reddit history
+          </div>
+          <div className="text-lg font-medium">
+            {locked ? (
+              "Connect your account to seed the model"
+            ) : (
+              <>
+                Recent activity for{" "}
+                <span style={{ color: "#fff" }}>u/{username}</span>
+              </>
+            )}
+          </div>
+        </div>
+        {locked ? (
+          <div />
+        ) : (
+          <div className="text-xs" style={{ color: "#9ca3af" }}>
+            {items.length} posts &amp; comments
+          </div>
+        )}
+      </div>
+
+      {locked && (
+        <div style={{ position: "relative", padding: "1.5rem" }}>
+          <div
+            style={{
+              filter: "blur(6px)",
+              opacity: 0.45,
+              pointerEvents: "none",
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.6rem",
+            }}
+          >
+            {items.slice(0, 3).map((it, i) => (
+              <RedditHistoryRow key={i} item={it} preview />
+            ))}
+          </div>
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              flexDirection: "column",
+              gap: "0.75rem",
+              background:
+                "radial-gradient(ellipse at center, rgba(0,0,0,0.4), rgba(0,0,0,0.7))",
+            }}
+          >
+            <LockIcon />
+            <div
+              className="text-sm"
+              style={{
+                maxWidth: 380,
+                textAlign: "center",
+                lineHeight: 1.5,
+                color: "#e5e7eb",
+              }}
+            >
+              Connect your Reddit username to import your past posts and
+              comments. The agent learns your tone from your own words.
+            </div>
+            <button
+              onClick={onConnect}
+              className="lr-btn-primary"
+              style={{ marginTop: "0.25rem" }}
+            >
+              Add username
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!locked && (
+        <div style={{ padding: "1.25rem 1.5rem" }}>
+          {!revealed ? (
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+              <PanelLoading
+                label={`Importing posts and comments from u/${username}…`}
+                rows={3}
+              />
+            </div>
+          ) : (
+            <>
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.6rem" }}>
+                {items.slice(0, shown).map((it, i) => (
+                  <RedditHistoryRow key={i} item={it} />
+                ))}
+              </div>
+              {shown < items.length && (
+                <div className="mt-5">
+                  <button
+                    onClick={() => setShown(items.length)}
+                    style={{
+                      background: "transparent",
+                      color: "#d1d5db",
+                      fontSize: 13,
+                      textDecoration: "underline",
+                      textUnderlineOffset: 4,
+                      padding: 0,
+                      border: "none",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Show {items.length - shown} more →
+                  </button>
+                </div>
+              )}
+              <div
+                className="mt-5 liquid-glass rounded-xl p-4"
+                style={{ border: "1px solid rgba(255,255,255,0.12)" }}
+              >
+                <div
+                  className="text-xs uppercase tracking-widest mb-2"
+                  style={{ color: "#9ca3af" }}
+                >
+                  Used for tone
+                </div>
+                <p
+                  className="text-sm leading-relaxed"
+                  style={{ color: "#e5e7eb" }}
+                >
+                  The agent treats this as ground truth for how you sound.
+                  Nothing is reposted, ever.
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RedditHistoryRow({
+  item,
+  preview,
+}: {
+  item: RedditItem;
+  preview?: boolean;
+}) {
+  const body = (item.body || "").replace(/\n+/g, " ").trim();
+  const truncated = body.length > 220 ? body.slice(0, 220) + "…" : body;
+  return (
+    <div
+      className="rounded-xl"
+      style={{
+        padding: "0.9rem 1rem",
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      <div
+        className="flex items-center justify-between mb-2"
+        style={{ gap: "0.75rem" }}
+      >
+        <div className="text-xs" style={{ color: "#d1d5db" }}>
+          r/{item.subreddit}
+        </div>
+        <div
+          className="text-xs"
+          style={{
+            color: "#9ca3af",
+            fontFamily: "ui-monospace, Menlo, Monaco, monospace",
+          }}
+        >
+          {formatRedditDate(item.created_utc)}
+        </div>
+      </div>
+      <p
+        className="text-sm"
+        style={{ color: "#e5e7eb", lineHeight: 1.5, margin: 0 }}
+      >
+        {truncated}
+      </p>
+      {!preview && (
+        <div className="mt-3">
+          <a
+            href={item.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs"
+            style={{
+              textDecoration: "underline",
+              textUnderlineOffset: 3,
+              color: "#9ca3af",
+            }}
+          >
+            View on Reddit →
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PaymentModal({
+  currentTokens,
+  onClose,
+  onTopUp,
+}: {
+  currentTokens: number;
+  onClose: () => void;
+  onTopUp: (qty: number) => void;
+}) {
+  const packs = [
+    { qty: 30, price: 19, label: "Starter" },
+    { qty: 120, price: 59, label: "Operator", best: true },
+    { qty: 500, price: 199, label: "Scale" },
+  ];
+  return (
+    <Modal onClose={onClose} title="Top up actions">
+      <p className="text-sm mb-2" style={{ color: "#d1d5db" }}>
+        Each action = one approved post, reply, or thread join.
+      </p>
+      <p
+        className="text-xs mb-5"
+        style={{
+          color: "#9ca3af",
+          fontFamily: "ui-monospace, Menlo, Monaco, monospace",
+        }}
+      >
+        Balance · <span style={{ color: "#fff" }}>{currentTokens}</span> actions
+      </p>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, minmax(0,1fr))",
+          gap: "0.75rem",
+        }}
+      >
+        {packs.map((p, i) => (
+          <button
+            key={i}
+            onClick={() => onTopUp(p.qty)}
+            className="rounded-xl text-left"
+            style={{
+              padding: "1rem",
+              background: "rgba(255,255,255,0.03)",
+              border: p.best
+                ? "1px solid rgba(255,255,255,0.55)"
+                : "1px solid rgba(255,255,255,0.12)",
+              color: "inherit",
+              cursor: "pointer",
+              position: "relative",
+            }}
+          >
+            {p.best && (
+              <div
+                style={{
+                  position: "absolute",
+                  top: -9,
+                  right: 10,
+                  fontSize: 9,
+                  letterSpacing: "0.15em",
+                  textTransform: "uppercase",
+                  color: "#000",
+                  background: "#fff",
+                  padding: "2px 6px",
+                  borderRadius: 999,
+                  fontWeight: 500,
+                }}
+              >
+                Best value
+              </div>
+            )}
+            <div
+              className="text-xs uppercase tracking-widest mb-2"
+              style={{ color: "#9ca3af" }}
+            >
+              {p.label}
+            </div>
+            <div
+              style={{
+                fontSize: "1.6rem",
+                letterSpacing: "-0.03em",
+                lineHeight: 1,
+              }}
+            >
+              {p.qty}
+            </div>
+            <div className="text-xs mt-1" style={{ color: "#9ca3af" }}>
+              actions
+            </div>
+            <div className="text-sm mt-3" style={{ color: "#fff" }}>
+              ${p.price}
+            </div>
+          </button>
+        ))}
+      </div>
+      <div
+        className="mt-5 liquid-glass rounded-xl p-3 flex items-center"
+        style={{ border: "1px solid rgba(255,255,255,0.1)", gap: "0.75rem" }}
+      >
+        <div
+          style={{
+            width: 36,
+            height: 24,
+            borderRadius: 4,
+            background: "linear-gradient(135deg,#222,#000)",
+            border: "1px solid rgba(255,255,255,0.15)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 10,
+            color: "#9ca3af",
+          }}
+        >
+          •••• 4242
+        </div>
+        <div className="text-xs" style={{ flex: 1, color: "#d1d5db" }}>
+          Charged to card on file.
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: "transparent",
+            color: "#9ca3af",
+            fontSize: 12,
+            padding: 0,
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          Change
+        </button>
+      </div>
+      <p className="text-xs mt-3" style={{ color: "#6b7280" }}>
+        Demo. No real charge.
+      </p>
+    </Modal>
+  );
+}
+
+function SettingsModal({
+  onClose,
+  username,
+  setUsername,
+  agentId,
+  setAgentId,
+}: {
+  onClose: () => void;
+  username: string;
+  setUsername: (v: string) => void;
+  agentId: string;
+  setAgentId: (id: string) => void;
+}) {
+  const [reddit, setReddit] = useState(username || "");
+  const [showAgentPicker, setShowAgentPicker] = useState(false);
+  const current = AGENTS.find((a) => a.id === agentId) || AGENTS[1];
+  return (
+    <Modal onClose={onClose} title="Settings">
+      <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+        {/* Agent */}
+        <div>
+          <label
+            className="text-xs uppercase tracking-widest mb-2"
+            style={{ display: "block", color: "#9ca3af" }}
+          >
+            Agent
+          </label>
+          <div
+            className="rounded-xl flex items-center justify-between"
+            style={{
+              background: "rgba(255,255,255,0.03)",
+              border: "1px solid rgba(255,255,255,0.12)",
+              padding: "0.5rem 0.5rem 0.5rem 0.75rem",
+              gap: "0.75rem",
+            }}
+          >
+            <div
+              className="flex items-center"
+              style={{ gap: "0.75rem", minWidth: 0 }}
+            >
+              <div style={{ width: 64, flexShrink: 0 }}>
+                <AgentSilhouette
+                  accent={current.accent}
+                  active
+                  vehicle={current.vehicle}
+                />
+              </div>
+              <div style={{ minWidth: 0 }}>
+                <div
+                  className="text-sm font-medium"
+                  style={{ color: "#fff" }}
+                >
+                  {current.name}
+                </div>
+                <div
+                  className="text-xs"
+                  style={{
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    color: "#9ca3af",
+                  }}
+                >
+                  {current.tagline}
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => setShowAgentPicker((v) => !v)}
+              style={{
+                background: "transparent",
+                color: "#fff",
+                fontSize: 13,
+                border: "1px solid rgba(255,255,255,0.2)",
+                borderRadius: 8,
+                padding: "0.4rem 0.9rem",
+                flexShrink: 0,
+                cursor: "pointer",
+              }}
+            >
+              {showAgentPicker ? "Done" : "Change"}
+            </button>
+          </div>
+          {showAgentPicker && (
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(2, minmax(0,1fr))",
+                gap: "0.5rem",
+                marginTop: "0.6rem",
+              }}
+            >
+              {AGENTS.map((a) => {
+                const sel = a.id === agentId;
+                return (
+                  <button
+                    key={a.id}
+                    onClick={() => setAgentId(a.id)}
+                    style={{
+                      background: sel
+                        ? "rgba(255,255,255,0.08)"
+                        : "rgba(255,255,255,0.02)",
+                      border: sel
+                        ? "1px solid rgba(255,255,255,0.5)"
+                        : "1px solid rgba(255,255,255,0.1)",
+                      borderRadius: 10,
+                      padding: "0.6rem",
+                      textAlign: "left",
+                      color: "inherit",
+                      cursor: "pointer",
+                      transition: "all 160ms ease",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.6rem",
+                    }}
+                  >
+                    <div style={{ width: 48, flexShrink: 0 }}>
+                      <AgentSilhouette
+                        accent={a.accent}
+                        active={sel}
+                        vehicle={a.vehicle}
+                      />
+                    </div>
+                    <div style={{ minWidth: 0 }}>
+                      <div
+                        className="text-xs"
+                        style={{ color: "#fff", fontWeight: 500 }}
+                      >
+                        {a.name}
+                      </div>
+                      <div
+                        className="text-xs"
+                        style={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          color: "#9ca3af",
+                        }}
+                      >
+                        {a.tagline}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          <p className="text-xs mt-2" style={{ color: "#6b7280" }}>
+            Switching agents changes voice on future drafts only.
+          </p>
+        </div>
+
+        {/* URL attribution */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label
+              className="text-xs uppercase tracking-widest"
+              style={{ color: "#9ca3af" }}
+            >
+              URL attribution
+            </label>
+            <span
+              className="text-xs"
+              style={{
+                color: "#9ca3af",
+                border: "1px solid rgba(255,255,255,0.15)",
+                borderRadius: 999,
+                padding: "2px 8px",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                fontSize: 10,
+              }}
+            >
+              Coming soon
+            </span>
+          </div>
+          <div
+            className="rounded-xl flex items-center"
+            style={{
+              padding: "0 0.25rem",
+              background: "rgba(255,255,255,0.02)",
+              border: "1px solid rgba(255,255,255,0.08)",
+              opacity: 0.6,
+              cursor: "not-allowed",
+            }}
+          >
+            <div
+              className="px-3 text-sm"
+              style={{
+                borderRight: "1px solid rgba(255,255,255,0.08)",
+                color: "#6b7280",
+              }}
+            >
+              utm
+            </div>
+            <input
+              disabled
+              placeholder="utm_source=legitreach"
+              style={{
+                background: "transparent",
+                color: "#9ca3af",
+                border: "none",
+                outline: "none",
+                padding: "0.75rem",
+                fontSize: "0.95rem",
+                fontFamily: "inherit",
+                width: "100%",
+                cursor: "not-allowed",
+              }}
+            />
+          </div>
+          <p className="text-xs mt-2" style={{ color: "#6b7280" }}>
+            Wire post-level attribution to Shopify and Stripe.
+          </p>
+        </div>
+
+        {/* Reddit username */}
+        <div>
+          <label
+            className="text-xs uppercase tracking-widest mb-2"
+            style={{ display: "block", color: "#9ca3af" }}
+          >
+            Your Reddit username
+          </label>
+          <div
+            className="rounded-xl flex items-center"
+            style={{
+              background: "rgba(0,0,0,0.4)",
+              border: "1px solid rgba(255,255,255,0.18)",
+            }}
+          >
+            <div
+              className="px-3 text-sm"
+              style={{
+                borderRight: "1px solid rgba(255,255,255,0.1)",
+                color: "#9ca3af",
+              }}
+            >
+              u/
+            </div>
+            <input
+              value={reddit}
+              onChange={(e) =>
+                setReddit(e.target.value.replace(/[^a-zA-Z0-9_-]/g, ""))
+              }
+              placeholder="your_handle"
+              style={{
+                background: "transparent",
+                color: "#fff",
+                border: "none",
+                outline: "none",
+                padding: "0.75rem",
+                fontSize: "0.95rem",
+                fontFamily: "inherit",
+                width: "100%",
+              }}
+            />
+          </div>
+          <p className="text-xs mt-2" style={{ color: "#6b7280" }}>
+            Used to identify which account the agent drafts for.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-end mt-6" style={{ gap: "0.75rem" }}>
+        <button
+          onClick={onClose}
+          style={{
+            background: "transparent",
+            color: "#d1d5db",
+            fontSize: 14,
+            padding: "0.5rem 1rem",
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={() => {
+            setUsername(reddit.trim());
+            onClose();
+          }}
+          className="lr-btn-nav"
+        >
+          Save
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/a16z/_steps.tsx
+++ b/src/app/a16z/_steps.tsx
@@ -1,0 +1,666 @@
+"use client";
+
+import React, { useState } from "react";
+import { FadeIn, AnimatedHeading } from "@/components/lr-design/visuals";
+import { Modal, BackgroundIndexer } from "./_chrome";
+import { AGENTS, Agent, AgentSilhouette, AgentStats } from "./_agents";
+
+// ─── Step 1: Persona ─────────────────────────────────────────
+export function Step1Persona({
+  onNext,
+  value,
+  setValue,
+}: {
+  onNext: () => void;
+  value: string;
+  setValue: (v: string) => void;
+}) {
+  const [showSoon, setShowSoon] = useState(false);
+  return (
+    <div
+      className="px-6 md:px-12 lg:px-16"
+      style={{ paddingTop: "8rem", paddingBottom: "5rem" }}
+    >
+      <div className="max-w-6xl mx-auto">
+        <FadeIn duration={700}>
+          <div
+            className="text-xs uppercase tracking-widest mb-6"
+            style={{ color: "#9ca3af" }}
+          >
+            Step 01 / Persona type
+          </div>
+        </FadeIn>
+        <AnimatedHeading
+          text="Create a digital clone for?"
+          className="text-3xl md:text-5xl lg:text-6xl font-normal mb-4"
+        />
+        <FadeIn delay={400} duration={700}>
+          <p
+            className="text-base md:text-lg mb-12"
+            style={{ maxWidth: "44rem", color: "#d1d5db" }}
+          >
+            Who is the agent going to represent? You can add more later.
+          </p>
+        </FadeIn>
+
+        <div
+          style={{
+            display: "grid",
+            gap: "1.5rem",
+            gridTemplateColumns: "repeat(2, minmax(0,1fr))",
+            alignItems: "stretch",
+          }}
+        >
+          <PersonaCard
+            primary
+            tag="Available now"
+            title="Business"
+            body="An agent that learns your brand, products, and audiences. Joins conversations where buyers already are."
+            kind="business"
+            value={value}
+            setValue={setValue}
+          />
+          <PersonaCard
+            disabled
+            tag="Coming soon"
+            title="Personal brand"
+            body="A digital twin for a creator, founder, or operator. Speaks in your voice across communities."
+            kind="personal"
+            value={value}
+            setValue={setValue}
+            onDisabledClick={() => setShowSoon(true)}
+          />
+        </div>
+
+        <FadeIn delay={600} duration={700}>
+          <div
+            className="mt-12 flex flex-wrap items-center"
+            style={{ gap: "1rem" }}
+          >
+            <button
+              onClick={onNext}
+              disabled={value !== "business"}
+              className="lr-btn-primary"
+              style={{
+                opacity: value === "business" ? 1 : 0.4,
+                cursor: value === "business" ? "pointer" : "not-allowed",
+              }}
+            >
+              Continue
+            </button>
+          </div>
+        </FadeIn>
+      </div>
+
+      {showSoon && (
+        <Modal
+          onClose={() => setShowSoon(false)}
+          title="Personal brand. Coming soon!"
+        >
+          <p
+            className="text-base leading-relaxed mb-2"
+            style={{ color: "#e5e7eb" }}
+          >
+            Individual online representation @ scale
+          </p>
+          <p
+            className="text-sm leading-relaxed"
+            style={{ color: "#9ca3af" }}
+          >
+            We are tuning the LegitReach model so a single voice scales across
+            communities without losing nuance.
+          </p>
+          <div className="flex justify-end mt-6" style={{ gap: "0.75rem" }}>
+            <button onClick={() => setShowSoon(false)} className="lr-btn-nav">
+              Got it
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+function PersonaCard({
+  disabled,
+  primary,
+  tag,
+  title,
+  body,
+  kind,
+  value,
+  setValue,
+  onDisabledClick,
+}: {
+  disabled?: boolean;
+  primary?: boolean;
+  tag: string;
+  title: string;
+  body: string;
+  kind: string;
+  value: string;
+  setValue: (v: string) => void;
+  onDisabledClick?: () => void;
+}) {
+  const selected = value === kind;
+  const borderColor = disabled
+    ? "rgba(255,255,255,0.10)"
+    : selected
+    ? "rgba(255,255,255,0.75)"
+    : primary
+    ? "rgba(255,255,255,0.35)"
+    : "rgba(255,255,255,0.18)";
+  return (
+    <button
+      onClick={() => {
+        if (disabled) {
+          if (onDisabledClick) onDisabledClick();
+          return;
+        }
+        setValue(kind);
+      }}
+      className="liquid-glass rounded-2xl text-left"
+      style={{
+        padding: "2rem",
+        border: `1px solid ${borderColor}`,
+        boxShadow:
+          primary && !disabled
+            ? "0 30px 60px -30px rgba(255,255,255,0.18)"
+            : "none",
+        opacity: disabled ? 0.55 : 1,
+        cursor: "pointer",
+        transition: "border-color 200ms ease, transform 200ms ease, box-shadow 200ms ease",
+        transform: selected ? "translateY(-2px)" : "none",
+        minHeight: "17rem",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        color: "inherit",
+        position: "relative",
+      }}
+    >
+      <div>
+        <div className="flex items-center justify-between mb-6">
+          <div
+            className="text-xs uppercase tracking-widest"
+            style={{ color: primary ? "#d1d5db" : "#9ca3af" }}
+          >
+            {tag}
+          </div>
+        </div>
+        <h3
+          className="font-normal mb-4"
+          style={{
+            letterSpacing: "-0.03em",
+            fontSize: "2.25rem",
+            lineHeight: 1.05,
+          }}
+        >
+          {title}
+        </h3>
+        <p
+          className="leading-relaxed"
+          style={{ fontSize: "0.975rem", color: primary ? "#e5e7eb" : "#9ca3af" }}
+        >
+          {body}
+        </p>
+      </div>
+    </button>
+  );
+}
+
+// ─── Step 2: Website / Description ─────────────────────────────
+export function Step2Website({
+  onNext,
+  website,
+  setWebsite,
+  manualDesc,
+  setManualDesc,
+}: {
+  onNext: () => void;
+  website: string;
+  setWebsite: (v: string) => void;
+  manualDesc: string;
+  setManualDesc: (v: string) => void;
+}) {
+  const [showModal, setShowModal] = useState(false);
+  const [draft, setDraft] = useState(manualDesc);
+
+  const canContinue =
+    website.trim().length > 4 || manualDesc.trim().length > 10;
+
+  return (
+    <div
+      className="px-6 md:px-12 lg:px-16"
+      style={{ paddingTop: "8rem", paddingBottom: "5rem" }}
+    >
+      <div className="max-w-4xl mx-auto">
+        <FadeIn duration={700}>
+          <div
+            className="text-xs uppercase tracking-widest mb-6"
+            style={{ color: "#9ca3af" }}
+          >
+            Step 02 / Source of truth
+          </div>
+        </FadeIn>
+        <AnimatedHeading
+          text="Where can we read about you?"
+          className="text-3xl md:text-5xl lg:text-6xl font-normal mb-4"
+        />
+        <FadeIn delay={400} duration={700}>
+          <p
+            className="text-base md:text-lg mb-12"
+            style={{ maxWidth: "44rem", color: "#d1d5db" }}
+          >
+            We crawl your site to learn products, audience, and voice. Takes
+            about ninety seconds.
+          </p>
+        </FadeIn>
+
+        <FadeIn delay={500} duration={700}>
+          <div
+            className="liquid-glass rounded-2xl p-2 mb-4"
+            style={{ border: "1px solid rgba(255,255,255,0.2)" }}
+          >
+            <div className="flex items-center" style={{ gap: 0 }}>
+              <div
+                className="px-4 text-sm"
+                style={{
+                  borderRight: "1px solid rgba(255,255,255,0.1)",
+                  color: "#9ca3af",
+                }}
+              >
+                https://
+              </div>
+              <input
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+                placeholder="yourbrand.com"
+                className="flex-1"
+                style={{
+                  background: "transparent",
+                  color: "#fff",
+                  border: "none",
+                  outline: "none",
+                  padding: "1rem",
+                  fontSize: "1.125rem",
+                  fontFamily: "inherit",
+                }}
+              />
+              {website && (
+                <div className="px-3 text-xs" style={{ color: "#9ca3af" }}>
+                  URL detected
+                </div>
+              )}
+            </div>
+          </div>
+        </FadeIn>
+
+        <FadeIn delay={600} duration={700}>
+          <button
+            onClick={() => {
+              setDraft(manualDesc);
+              setShowModal(true);
+            }}
+            style={{
+              background: "transparent",
+              color: "#d1d5db",
+              fontSize: "0.95rem",
+              textDecoration: "underline",
+              textUnderlineOffset: "4px",
+              padding: 0,
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            No website? Describe your business instead →
+          </button>
+        </FadeIn>
+
+        {manualDesc && (
+          <FadeIn delay={300} duration={700}>
+            <div
+              className="liquid-glass rounded-xl p-4 mt-6"
+              style={{ border: "1px solid rgba(255,255,255,0.18)" }}
+            >
+              <div
+                className="text-xs uppercase tracking-widest mb-2"
+                style={{ color: "#9ca3af" }}
+              >
+                Manual description
+              </div>
+              <p
+                className="text-sm"
+                style={{ whiteSpace: "pre-wrap", color: "#f3f4f6" }}
+              >
+                {manualDesc}
+              </p>
+            </div>
+          </FadeIn>
+        )}
+
+        <FadeIn delay={700} duration={700}>
+          <div
+            className="mt-12 flex flex-wrap items-center"
+            style={{ gap: "1rem" }}
+          >
+            <button
+              onClick={onNext}
+              disabled={!canContinue}
+              className="lr-btn-primary"
+              style={{
+                opacity: canContinue ? 1 : 0.4,
+                cursor: canContinue ? "pointer" : "not-allowed",
+              }}
+            >
+              Continue
+            </button>
+            <span className="text-sm" style={{ color: "#9ca3af" }}>
+              We never post or change anything on your site.
+            </span>
+          </div>
+        </FadeIn>
+      </div>
+
+      {showModal && (
+        <Modal
+          onClose={() => setShowModal(false)}
+          title="Tell us about your business"
+        >
+          <p className="text-sm mb-4" style={{ color: "#d1d5db" }}>
+            A few sentences. What you sell, who buys, and how you sound.
+          </p>
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={6}
+            placeholder={
+              "E.g. We sell minimalist skincare for sensitive skin. Customers are millennials in the US who care about ingredients. Friendly, science-led tone."
+            }
+            style={{
+              width: "100%",
+              background: "rgba(0,0,0,0.4)",
+              color: "#fff",
+              border: "1px solid rgba(255,255,255,0.15)",
+              borderRadius: 12,
+              padding: "1rem",
+              fontSize: "0.95rem",
+              fontFamily: "inherit",
+              outline: "none",
+              resize: "vertical",
+            }}
+          />
+          <div className="flex justify-end mt-6" style={{ gap: "0.75rem" }}>
+            <button
+              onClick={() => setShowModal(false)}
+              style={{
+                background: "transparent",
+                color: "#d1d5db",
+                padding: "0.5rem 1rem",
+                fontSize: 14,
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => {
+                setManualDesc(draft);
+                setShowModal(false);
+              }}
+              className="lr-btn-nav"
+            >
+              Save
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+// ─── Step 3: Agent ─────────────────────────────────────────
+export function Step3Agent({
+  onNext,
+  agentId,
+  setAgentId,
+  custom,
+  setCustom,
+}: {
+  onNext: () => void;
+  agentId: string;
+  setAgentId: (id: string) => void;
+  custom: AgentStats | null;
+  setCustom: (s: AgentStats) => void;
+}) {
+  const agent: Agent = AGENTS.find((a) => a.id === agentId) || AGENTS[1];
+  const view: AgentStats = custom ?? agent.stats;
+  const update = (patch: Partial<AgentStats>) =>
+    setCustom({ ...view, ...patch });
+
+  return (
+    <div
+      className="px-6 md:px-12 lg:px-16"
+      style={{ paddingTop: "8rem", paddingBottom: "5rem" }}
+    >
+      <div className="max-w-7xl mx-auto">
+        <div
+          className="flex items-center justify-between mb-6"
+          style={{ flexWrap: "wrap", gap: "0.75rem" }}
+        >
+          <FadeIn duration={700}>
+            <div
+              className="text-xs uppercase tracking-widest"
+              style={{ color: "#9ca3af" }}
+            >
+              Step 03 / Tone of voice
+            </div>
+          </FadeIn>
+          <FadeIn delay={200} duration={700}>
+            <BackgroundIndexer />
+          </FadeIn>
+        </div>
+        <AnimatedHeading
+          text="Pick your agent."
+          className="text-3xl md:text-5xl lg:text-6xl font-normal mb-4"
+        />
+        <FadeIn delay={300} duration={700}>
+          <p
+            className="text-base md:text-lg mb-10"
+            style={{ maxWidth: "44rem", color: "#d1d5db" }}
+          >
+            Each one drafts differently. You can tweak the stats. The agent
+            learns your real voice from approved posts.
+          </p>
+        </FadeIn>
+
+        <div
+          style={{
+            display: "grid",
+            gap: "1.5rem",
+            gridTemplateColumns: "minmax(0,1.4fr) minmax(0,1fr)",
+          }}
+        >
+          <div
+            className="liquid-glass rounded-2xl p-6"
+            style={{ border: "1px solid rgba(255,255,255,0.18)" }}
+          >
+            <div
+              className="text-xs uppercase tracking-widest mb-4"
+              style={{ color: "#9ca3af" }}
+            >
+              Garage
+            </div>
+            <div
+              className="grid grid-cols-2"
+              style={{ gap: "0.75rem", display: "grid" }}
+            >
+              {AGENTS.map((a) => {
+                const sel = a.id === agentId;
+                return (
+                  <button
+                    key={a.id}
+                    onClick={() => setAgentId(a.id)}
+                    className="rounded-xl"
+                    style={{
+                      background: sel
+                        ? "rgba(255,255,255,0.08)"
+                        : "rgba(255,255,255,0.02)",
+                      border: sel
+                        ? "1px solid rgba(255,255,255,0.5)"
+                        : "1px solid rgba(255,255,255,0.1)",
+                      padding: "1rem",
+                      textAlign: "left",
+                      color: "inherit",
+                      transition: "all 180ms ease",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <AgentSilhouette accent={a.accent} active={sel} vehicle={a.vehicle} />
+                    <div className="mt-3 text-base font-medium">{a.name}</div>
+                    <div className="text-xs mt-1" style={{ color: "#9ca3af" }}>
+                      {a.tagline}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div
+            className="liquid-glass rounded-2xl p-8"
+            style={{
+              border: "1px solid rgba(255,255,255,0.18)",
+              display: "flex",
+              flexDirection: "column",
+              gap: "1.5rem",
+            }}
+          >
+            <div>
+              <div
+                className="text-xs uppercase tracking-widest mb-2"
+                style={{ color: "#9ca3af" }}
+              >
+                Selected
+              </div>
+              <h3
+                className="text-3xl md:text-4xl font-normal"
+                style={{ letterSpacing: "-0.03em" }}
+              >
+                {agent.name}
+              </h3>
+              <div className="text-sm mt-1" style={{ color: "#d1d5db" }}>
+                {agent.tagline}
+              </div>
+            </div>
+
+            {(
+              ["warmth", "wit", "formality", "brevity", "assertiveness"] as Array<
+                keyof AgentStats
+              >
+            ).map((k) => (
+              <StatRow
+                key={k}
+                label={k[0].toUpperCase() + k.slice(1)}
+                value={view[k]}
+                onChange={(v) => update({ [k]: v } as Partial<AgentStats>)}
+              />
+            ))}
+
+            <div>
+              <div
+                className="text-xs uppercase tracking-widest mb-2"
+                style={{ color: "#9ca3af" }}
+              >
+                Sample reply
+              </div>
+              <div
+                className="text-sm leading-relaxed"
+                style={{
+                  fontStyle: "italic",
+                  borderLeft: "2px solid rgba(255,255,255,0.3)",
+                  paddingLeft: "0.75rem",
+                  color: "#f3f4f6",
+                }}
+              >
+                {agent.sample}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <FadeIn delay={400} duration={700}>
+          <div
+            className="mt-12 flex flex-wrap items-center"
+            style={{ gap: "1rem" }}
+          >
+            <button onClick={onNext} className="lr-btn-primary">
+              Take it for a spin
+            </button>
+            <span className="text-sm" style={{ color: "#9ca3af" }}>
+              You can change agents and stats any time.
+            </span>
+          </div>
+        </FadeIn>
+      </div>
+    </div>
+  );
+}
+
+function StatRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div>
+      <div
+        className="flex justify-between text-xs uppercase tracking-widest mb-2"
+        style={{ color: "#9ca3af" }}
+      >
+        <span>{label}</span>
+        <span style={{ color: "#fff" }}>{value}</span>
+      </div>
+      <div
+        style={{
+          position: "relative",
+          height: 6,
+          background: "rgba(255,255,255,0.08)",
+          borderRadius: 999,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            height: "100%",
+            width: `${value}%`,
+            background: "#fff",
+            borderRadius: 999,
+          }}
+        />
+        <input
+          type="range"
+          min="0"
+          max="100"
+          value={value}
+          onChange={(e) => onChange(parseInt(e.target.value))}
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            opacity: 0,
+            cursor: "pointer",
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/a16z/page.tsx
+++ b/src/app/a16z/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React, { useState } from "react";
+import { Backdrop } from "@/components/lr-design/visuals";
+import { TopBar } from "./_chrome";
+import { Step1Persona, Step2Website, Step3Agent } from "./_steps";
+import { Step4Dashboard } from "./_dashboard";
+import type { AgentStats } from "./_agents";
+
+export default function A16zOnboarding() {
+  const [step, setStep] = useState(1);
+  const [persona, setPersona] = useState("business");
+  const [website, setWebsite] = useState("");
+  const [manualDesc, setManualDesc] = useState("");
+  const [agentId, setAgentId] = useState("classic");
+  const [custom, setCustom] = useState<AgentStats | null>(null);
+
+  const total = 3;
+
+  return (
+    <div
+      className="lr-design"
+      style={{ minHeight: "100vh", background: "#000" }}
+    >
+      <Backdrop />
+      <TopBar
+        step={step}
+        total={total}
+        onBack={() => setStep((s) => Math.max(1, s - 1))}
+      />
+      <main style={{ position: "relative", zIndex: 10, minHeight: "100vh" }}>
+        {step === 1 && (
+          <Step1Persona
+            value={persona}
+            setValue={setPersona}
+            onNext={() => setStep(2)}
+          />
+        )}
+        {step === 2 && (
+          <Step2Website
+            website={website}
+            setWebsite={setWebsite}
+            manualDesc={manualDesc}
+            setManualDesc={setManualDesc}
+            onNext={() => setStep(3)}
+          />
+        )}
+        {step === 3 && (
+          <Step3Agent
+            agentId={agentId}
+            setAgentId={setAgentId}
+            custom={custom}
+            setCustom={setCustom}
+            onNext={() => setStep(4)}
+          />
+        )}
+        {step === 4 && (
+          <Step4Dashboard agentId={agentId} setAgentId={setAgentId} />
+        )}
+      </main>
+      <footer
+        className="px-6 md:px-12 lg:px-16 py-6"
+        style={{
+          position: "relative",
+          zIndex: 10,
+          borderTop: "1px solid rgba(255,255,255,0.08)",
+        }}
+      >
+        <div
+          className="flex justify-between"
+          style={{
+            flexWrap: "wrap",
+            gap: "0.5rem",
+            fontSize: "0.75rem",
+            color: "#9ca3af",
+          }}
+        >
+          <div>LegitReach. The world model for online communities.</div>
+          <a
+            href="mailto:manthan@legitreach.com"
+            style={{ transition: "color 200ms ease" }}
+          >
+            Contact for bugs: manthan@legitreach.com
+          </a>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/beta/page.tsx
+++ b/src/app/beta/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useApp } from "@/context/AppContext";
+import { WaitlistExperience } from "@/components/ui/waitlist-landing-page-with-countdown-timer";
+import {
+  SignInButton,
+  UserButton,
+  SignedIn,
+  SignedOut,
+  useAuth
+} from "@clerk/nextjs";
+import Link from "next/link";
+import React, { useEffect } from "react";
+import posthog from "posthog-js";
+
+export default function Home() {
+  const router = useRouter();
+  const { onboarding, isAppLoaded } = useApp();
+  const { isSignedIn, isLoaded } = useAuth();
+
+  useEffect(() => {
+    if (isLoaded && isSignedIn && isAppLoaded && onboarding.completed) {
+      router.push("/terminal");
+    }
+  }, [isLoaded, isSignedIn, isAppLoaded, onboarding.completed, router]);
+  return (
+    <div className="relative min-h-screen">
+      {/* Absolute Header for Login/Dashboard Access */}
+      <div className="absolute top-4 right-4 md:top-8 md:right-8 z-50 flex items-center gap-4">
+        <SignedOut>
+          <Link
+            href="/onboarding"
+            className="text-sm font-medium text-primary-foreground bg-primary hover:brightness-110 px-4 py-2 rounded-full transition-all shadow-[0_0_15px_rgba(114,227,173,0.3)] hover:shadow-[0_0_25px_rgba(114,227,173,0.5)]"
+            onClick={() => posthog.capture("try_for_free_clicked")}
+          >
+            Start for Free
+          </Link>
+          <SignInButton mode="modal">
+            <button
+              className="text-sm font-medium text-foreground/70 hover:text-foreground px-4 py-2 rounded-full border border-border hover:border-primary bg-card/40 backdrop-blur-md transition-all"
+              onClick={() => posthog.capture("sign_in_clicked")}
+            >
+              Sign In
+            </button>
+          </SignInButton>
+        </SignedOut>
+        <SignedIn>
+          <Link
+            href="/terminal"
+            className="text-sm font-medium text-foreground/90 hover:text-foreground px-4 py-2 rounded-full border border-primary/30 hover:border-primary bg-primary/10 backdrop-blur-md transition-all shadow-[0_0_15px_rgba(114,227,173,0.1)] hover:shadow-[0_0_20px_rgba(114,227,173,0.3)] mr-2"
+          >
+            Go to Terminal
+          </Link>
+          <UserButton />
+        </SignedIn>
+      </div>
+
+      {/* Main Waitlist Experience Component */}
+      <WaitlistExperience />
+    </div>
+  );
+}

--- a/src/app/building/page.tsx
+++ b/src/app/building/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { Reveal } from "@/components/lr-design/visuals";
+import Nav from "@/components/lr-design/Nav";
+
+export default function BuildingPage() {
+  const livePoints = [
+    "Every Reddit post is a controlled rehearsal. Multiple agents draft. Real humans choose. We draft at superhuman pace & we post at human pace.",
+    "You are the agent. Agents have a derived voice of tone from the user, guided by a real person. We do not flood. We do not fake. We only automate the friction away.",
+    "High-intent buying conversations become authentic engagement, attributed to revenue through UTM links.",
+  ];
+
+  const stats = [
+    { num: "3", label: "paying customers" },
+    { num: "$600", label: "MRR" },
+    { num: "5 min", label: "per day / brand" },
+  ];
+
+  const nextPoints = [
+    'A simulator, which is internally referred to as: the "Full Power" engine, simulates online communities in a visual format.\n\nEducators & students learn trading information online by interacting with the model.',
+    "First LOI signed with an education institute. Open for partners.",
+  ];
+
+  return (
+    <div
+      className="lr-design"
+      style={{
+        minHeight: "100vh",
+        background: "#000",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Nav current="/building" />
+
+      <main style={{ flex: 1, paddingTop: "6rem" }}>
+        <section
+          className="px-6 md:px-12 lg:px-16 py-32"
+          style={{ minHeight: "100vh" }}
+        >
+          <div className="max-w-5xl" style={{ paddingTop: "4rem" }}>
+            <Reveal>
+              <div
+                className="text-xs uppercase mb-8"
+                style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+              >
+                A / Live today
+              </div>
+            </Reveal>
+            <Reveal delay={120}>
+              <h1
+                className="text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-normal mb-10 leading-tight"
+                style={{ letterSpacing: "-0.04em" }}
+              >
+                Reddit Representation. Live today.
+              </h1>
+            </Reveal>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "1.25rem",
+                maxWidth: "46rem",
+                marginBottom: "3rem",
+              }}
+            >
+              {livePoints.map((p, i) => (
+                <Reveal key={i} delay={220 + i * 100}>
+                  <p
+                    className="text-lg md:text-xl leading-relaxed"
+                    style={{ whiteSpace: "pre-line", color: "#d1d5db" }}
+                  >
+                    {p}
+                  </p>
+                </Reveal>
+              ))}
+            </div>
+
+            <Reveal delay={560}>
+              <div
+                className="md:grid md:grid-cols-3 gap-6"
+                style={{ marginBottom: "2.5rem" }}
+              >
+                {stats.map((s, i) => (
+                  <div
+                    key={i}
+                    className="liquid-glass rounded-xl p-8"
+                    style={{ border: "1px solid rgba(255,255,255,0.2)" }}
+                  >
+                    <div className="stat-num mb-3">{s.num}</div>
+                    <div
+                      className="text-sm"
+                      style={{ color: "#d1d5db" }}
+                    >
+                      {s.label}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Reveal>
+
+            <Reveal delay={700}>
+              <a href="/a16z" className="lr-btn-primary inline-block">
+                Try the product now!
+              </a>
+            </Reveal>
+          </div>
+        </section>
+
+        <section
+          className="px-6 md:px-12 lg:px-16 py-32"
+          style={{
+            minHeight: "100vh",
+            borderTop: "1px solid rgba(255,255,255,0.08)",
+          }}
+        >
+          <div className="max-w-5xl">
+            <Reveal>
+              <div
+                className="text-xs uppercase mb-8"
+                style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+              >
+                B / Coming next
+              </div>
+            </Reveal>
+            <Reveal delay={120}>
+              <h2
+                className="text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-normal mb-10 leading-tight"
+                style={{ letterSpacing: "-0.04em" }}
+              >
+                Visualize online communities by simulating it.
+              </h2>
+            </Reveal>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "1.25rem",
+                maxWidth: "46rem",
+                marginBottom: "3rem",
+              }}
+            >
+              {nextPoints.map((p, i) => (
+                <Reveal key={i} delay={220 + i * 100}>
+                  <p
+                    className="text-lg md:text-xl leading-relaxed"
+                    style={{ whiteSpace: "pre-line", color: "#d1d5db" }}
+                  >
+                    {p}
+                  </p>
+                </Reveal>
+              ))}
+            </div>
+            <Reveal delay={500}>
+              <a
+                href="mailto:manthan@legitreach.com"
+                className="lr-btn-primary inline-block"
+              >
+                Partner with us
+              </a>
+            </Reveal>
+          </div>
+        </section>
+      </main>
+
+      <footer
+        className="px-6 md:px-12 lg:px-16 py-6 flex justify-between"
+        style={{
+          borderTop: "1px solid rgba(255,255,255,0.10)",
+          color: "#d1d5db",
+          fontSize: "0.75rem",
+          flexWrap: "wrap",
+          gap: "0.5rem",
+        }}
+      >
+        <div>LegitReach. Manage real online presence with ease.</div>
+        <a
+          href="mailto:manthan@legitreach.com"
+          style={{ transition: "color 200ms ease" }}
+        >
+          Report Bugs: manthan@legitreach.com
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -618,3 +618,187 @@ img {
   background: var(--color-primary);
   color: var(--primary-foreground);
 }
+
+/* ─────────────────────────────────────────────────────────────
+   LegitReach a16z Demo Design — scoped under .lr-design wrapper
+   ───────────────────────────────────────────────────────────── */
+.lr-design {
+  font-family: 'Inter', sans-serif;
+  background: #000;
+  color: #fff;
+  min-height: 100vh;
+}
+.lr-design * { box-sizing: border-box; }
+.lr-design a { color: inherit; text-decoration: none; }
+.lr-design button { font-family: inherit; cursor: pointer; }
+
+.lr-design .liquid-glass {
+  background: rgba(0, 0, 0, 0.4);
+  background-blend-mode: luminosity;
+  backdrop-filter: blur(10px) saturate(140%);
+  -webkit-backdrop-filter: blur(10px) saturate(140%);
+  border: none;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.1);
+  position: relative;
+  overflow: hidden;
+}
+.lr-design .liquid-glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.4px;
+  background: linear-gradient(180deg,
+    rgba(255,255,255,0.3) 0%, rgba(255,255,255,0.1) 20%,
+    rgba(255,255,255,0) 40%, rgba(255,255,255,0) 60%,
+    rgba(255,255,255,0.1) 80%, rgba(255,255,255,0.3) 100%);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.lr-design .scene-bg {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at 50% 80%, #0a0a0a 0%, #000 60%);
+  overflow: hidden;
+}
+.lr-design .scene-stars::before,
+.lr-design .scene-stars::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(1px 1px at 12% 18%, rgba(255,255,255,0.6), transparent 50%),
+    radial-gradient(1px 1px at 23% 32%, rgba(255,255,255,0.4), transparent 50%),
+    radial-gradient(1.5px 1.5px at 38% 12%, rgba(255,255,255,0.7), transparent 50%),
+    radial-gradient(1px 1px at 55% 22%, rgba(255,255,255,0.3), transparent 50%),
+    radial-gradient(1px 1px at 71% 14%, rgba(255,255,255,0.5), transparent 50%),
+    radial-gradient(1px 1px at 84% 28%, rgba(255,255,255,0.4), transparent 50%),
+    radial-gradient(1.5px 1.5px at 92% 18%, rgba(255,255,255,0.6), transparent 50%),
+    radial-gradient(1px 1px at 9% 8%, rgba(255,255,255,0.5), transparent 50%);
+  animation: lr-twinkle 6s ease-in-out infinite alternate;
+}
+@keyframes lr-twinkle {
+  from { opacity: 0.4; }
+  to   { opacity: 0.95; }
+}
+
+.lr-design .scene-floor {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 55%;
+  background:
+    linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.6) 80%, #000 100%),
+    repeating-linear-gradient(to right,
+      rgba(255,255,255,0.08) 0 1px, transparent 1px 60px),
+    repeating-linear-gradient(to bottom,
+      rgba(255,255,255,0.08) 0 1px, transparent 1px 60px);
+  transform: perspective(800px) rotateX(62deg);
+  transform-origin: bottom;
+}
+.lr-design .scene-haze {
+  position: absolute;
+  left: 0; right: 0; bottom: 30%;
+  height: 25%;
+  background: linear-gradient(to top, rgba(255,255,255,0.06), transparent);
+  filter: blur(20px);
+  pointer-events: none;
+}
+.lr-design .scene {
+  position: absolute;
+  inset: 0;
+  perspective: 1000px;
+  overflow: hidden;
+}
+
+.lr-design .blink { animation: lr-blink 2.2s ease-in-out infinite alternate; }
+.lr-design .blink-2 { animation-delay: 0.6s; }
+.lr-design .blink-3 { animation-delay: 1.2s; }
+.lr-design .blink-4 { animation-delay: 1.8s; }
+@keyframes lr-blink {
+  from { opacity: 0.2; }
+  to   { opacity: 1; }
+}
+
+@keyframes lr-pulse-dot {
+  0%   { transform: translate(0,0); opacity: 0; }
+  10%  { opacity: 1; }
+  90%  { opacity: 1; }
+  100% { transform: translate(var(--dx), var(--dy)); opacity: 0; }
+}
+
+.lr-design .reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 900ms cubic-bezier(0.2,0.7,0.2,1), transform 900ms cubic-bezier(0.2,0.7,0.2,1);
+}
+.lr-design .reveal.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.lr-design .lr-btn-primary {
+  background: #fff; color: #000;
+  padding: 0.75rem 2rem;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: background 180ms ease, transform 180ms ease;
+  border: none;
+  display: inline-block;
+}
+.lr-design .lr-btn-primary:hover:not(:disabled) { background: #e9e9e9; }
+.lr-design .lr-btn-ghost {
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.2);
+  padding: 0.75rem 2rem;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: background 180ms ease, color 180ms ease;
+  background: transparent;
+  display: inline-block;
+}
+.lr-design .lr-btn-ghost:hover { background: #fff; color: #000; }
+.lr-design .lr-btn-nav {
+  background: #fff; color: #000;
+  padding: 0.5rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: background 180ms ease;
+  border: none;
+}
+.lr-design .lr-btn-nav:hover { background: #f3f4f6; }
+
+.lr-design .lr-nav-link {
+  font-size: 0.875rem;
+  color: #fff;
+  transition: color 180ms ease;
+}
+.lr-design .lr-nav-link:hover { color: #d1d5db; }
+
+.lr-design .stat-num {
+  font-size: 3rem;
+  line-height: 1;
+  font-weight: 400;
+  letter-spacing: -0.03em;
+}
+@media (min-width: 768px) {
+  .lr-design .stat-num { font-size: 3.75rem; }
+}
+
+.lr-design .text-shadow-soft {
+  text-shadow: 0 2px 30px rgba(0,0,0,0.55);
+}
+
+@keyframes lr-shimmer {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+@keyframes lr-pulse-soft {
+  0%, 100% { opacity: 0.4; transform: scale(1); }
+  50%      { opacity: 1;   transform: scale(1.4); }
+}

--- a/src/app/invest/page.tsx
+++ b/src/app/invest/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  AnimatedHeading,
+  DigitalDowntown,
+  FadeIn,
+  Reveal,
+} from "@/components/lr-design/visuals";
+import Nav from "@/components/lr-design/Nav";
+
+function PitchDeckOverlay({ onClose }: { onClose: () => void }) {
+  const handleDownload = () => {
+    const iframe = document.getElementById(
+      "pitch-deck-iframe"
+    ) as HTMLIFrameElement | null;
+    try {
+      iframe?.contentWindow?.print();
+    } catch {
+      window.open("/pitch-deck.html", "_blank", "noopener");
+    }
+  };
+
+  const close = useCallback(() => onClose(), [onClose]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [close]);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 200,
+        background: "rgba(0,0,0,0.92)",
+        backdropFilter: "blur(10px)",
+        WebkitBackdropFilter: "blur(10px)",
+        display: "flex",
+        flexDirection: "column",
+      }}
+      onClick={close}
+    >
+      {/* Top bar */}
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "1.25rem 1.5rem",
+          borderBottom: "1px solid rgba(255,255,255,0.08)",
+          flexShrink: 0,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          <div
+            style={{ fontSize: "1.25rem", fontWeight: 600, letterSpacing: "-0.03em" }}
+          >
+            LegitReach
+          </div>
+          <span style={{ color: "rgba(255,255,255,0.25)" }}>/</span>
+          <span
+            className="text-xs uppercase"
+            style={{ letterSpacing: "0.12em", color: "#d1d5db" }}
+          >
+            Pitch deck
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <button
+            onClick={handleDownload}
+            className="lr-btn-nav"
+            style={{ cursor: "pointer" }}
+          >
+            Download PDF
+          </button>
+          <button
+            onClick={close}
+            aria-label="Close"
+            style={{
+              background: "transparent",
+              color: "#fff",
+              border: "1px solid rgba(255,255,255,0.18)",
+              borderRadius: 999,
+              width: 36,
+              height: 36,
+              fontSize: 20,
+              lineHeight: 1,
+              cursor: "pointer",
+            }}
+          >
+            ×
+          </button>
+        </div>
+      </div>
+
+      {/* Iframe */}
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{ flex: 1, position: "relative", overflow: "hidden" }}
+      >
+        <iframe
+          id="pitch-deck-iframe"
+          src="/pitch-deck.html"
+          title="LegitReach pitch deck"
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            border: "none",
+            background: "#000",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function InvestPage() {
+  const [showDeck, setShowDeck] = useState(false);
+  return (
+    <div
+      className="lr-design"
+      style={{
+        minHeight: "100vh",
+        background: "#000",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Nav current="/invest" />
+
+      <main style={{ flex: 1 }}>
+        {/* Vision section */}
+        <section
+          className="relative w-full"
+          style={{ minHeight: "100vh", overflow: "hidden" }}
+        >
+          <div style={{ position: "absolute", inset: 0 }}>
+            <DigitalDowntown />
+          </div>
+          <div
+            className="px-6 md:px-12 lg:px-16 lg:pb-16 pb-12"
+            style={{
+              position: "relative",
+              minHeight: "100vh",
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "flex-end",
+              zIndex: 20,
+            }}
+          >
+            <div style={{ maxWidth: "56rem" }} className="text-shadow-soft">
+              <FadeIn delay={100} duration={800}>
+                <div
+                  className="text-xs uppercase mb-6"
+                  style={{
+                    letterSpacing: "0.15em",
+                    color: "#d1d5db",
+                  }}
+                >
+                  Vision
+                </div>
+              </FadeIn>
+              <AnimatedHeading
+                text={"Creating a world model\nfor online commerce."}
+                className="text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-normal mb-6"
+              />
+              <FadeIn delay={1200} duration={1000}>
+                <p
+                  className="text-base md:text-lg mb-8"
+                  style={{
+                    maxWidth: "40rem",
+                    color: "#d1d5db",
+                  }}
+                >
+                  Simulator where online buyers & sellers rehearse negotiations
+                  before it actually happens.
+                </p>
+              </FadeIn>
+              <FadeIn delay={1500} duration={1000}>
+                <a
+                  href="mailto:manthan@legitreach.com"
+                  className="lr-btn-primary"
+                >
+                  Start a Chat
+                </a>
+              </FadeIn>
+            </div>
+          </div>
+        </section>
+
+        {/* Invest section */}
+        <section
+          className="px-6 md:px-12 lg:px-16 py-32"
+          style={{
+            minHeight: "100vh",
+            borderTop: "1px solid rgba(255,255,255,0.08)",
+          }}
+        >
+          <div className="max-w-5xl" style={{ paddingTop: "4rem" }}>
+            <Reveal>
+              <div
+                className="text-xs uppercase mb-8"
+                style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+              >
+                Invest
+              </div>
+            </Reveal>
+            <Reveal delay={120}>
+              <h1
+                className="text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-normal mb-10 leading-tight"
+                style={{ letterSpacing: "-0.04em" }}
+              >
+                Invest in the model for simulating online commerce.
+              </h1>
+            </Reveal>
+            <Reveal delay={220}>
+              <p
+                className="text-lg md:text-xl mb-10 leading-relaxed"
+                style={{ maxWidth: "46rem", color: "#d1d5db" }}
+              >
+                Starting with simulators for online communities.
+              </p>
+            </Reveal>
+
+            <div
+              className="md:grid md:grid-cols-2 gap-8"
+              style={{ marginBottom: "4rem" }}
+            >
+              <Reveal delay={300}>
+                <div
+                  className="liquid-glass rounded-xl p-8"
+                  style={{
+                    height: "100%",
+                    border: "1px solid rgba(255,255,255,0.2)",
+                  }}
+                >
+                  <div
+                    className="text-xs uppercase mb-4"
+                    style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+                  >
+                    Today
+                  </div>
+                  <p
+                    className="text-lg md:text-xl leading-relaxed"
+                    style={{ color: "#f3f4f6" }}
+                  >
+                    Authentic Reddit representation for 3 consumer electronics
+                    e-commerce brands. Paying customers charged $200 per seat.
+                  </p>
+                </div>
+              </Reveal>
+              <Reveal delay={400}>
+                <div
+                  className="liquid-glass rounded-xl p-8"
+                  style={{
+                    height: "100%",
+                    border: "1px solid rgba(255,255,255,0.2)",
+                  }}
+                >
+                  <div
+                    className="text-xs uppercase mb-4"
+                    style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+                  >
+                    Planned
+                  </div>
+                  <p
+                    className="text-lg md:text-xl leading-relaxed"
+                    style={{ color: "#f3f4f6" }}
+                  >
+                    Every post on every community becomes labeled training
+                    data. The reinforcement flywheel ships in 6 months.
+                  </p>
+                </div>
+              </Reveal>
+            </div>
+
+            <Reveal delay={500}>
+              <div
+                className="liquid-glass rounded-xl p-10"
+                style={{
+                  maxWidth: "38rem",
+                  border: "1px solid rgba(255,255,255,0.2)",
+                }}
+              >
+                <div
+                  className="text-xs uppercase mb-4"
+                  style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+                >
+                  The round
+                </div>
+                <h3
+                  className="text-4xl md:text-5xl font-normal mb-3"
+                  style={{ letterSpacing: "-0.04em" }}
+                >
+                  Actively raising pre-seed
+                </h3>
+                <p
+                  className="text-base md:text-lg mb-2"
+                  style={{ color: "#d1d5db" }}
+                >
+                  YC-style SAFE.
+                </p>
+                <p
+                  className="text-base md:text-lg mb-8"
+                  style={{ color: "#d1d5db" }}
+                >
+                  Closing 06/06/2026.
+                </p>
+                <div className="flex flex-wrap" style={{ gap: "0.75rem" }}>
+                  <a
+                    href="mailto:manthan@legitreach.com"
+                    className="lr-btn-primary inline-block"
+                  >
+                    Invest now
+                  </a>
+                  <button
+                    onClick={() => setShowDeck(true)}
+                    className="lr-btn-ghost liquid-glass inline-block"
+                    style={{ cursor: "pointer" }}
+                  >
+                    Pitch deck
+                  </button>
+                </div>
+              </div>
+            </Reveal>
+          </div>
+        </section>
+      </main>
+
+      <footer
+        className="px-6 md:px-12 lg:px-16 py-6 flex justify-between"
+        style={{
+          borderTop: "1px solid rgba(255,255,255,0.10)",
+          color: "#d1d5db",
+          fontSize: "0.75rem",
+          flexWrap: "wrap",
+          gap: "0.5rem",
+        }}
+      >
+        <div>LegitReach. Manage real online presence with ease.</div>
+        <a
+          href="mailto:manthan@legitreach.com"
+          style={{ transition: "color 200ms ease" }}
+        >
+          Report Bugs: manthan@legitreach.com
+        </a>
+      </footer>
+
+      {showDeck && <PitchDeckOverlay onClose={() => setShowDeck(false)} />}
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,63 +1,106 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useApp } from "@/context/AppContext";
-import { WaitlistExperience } from "@/components/ui/waitlist-landing-page-with-countdown-timer";
-import {
-  SignInButton,
-  UserButton,
-  SignedIn,
-  SignedOut,
-  useAuth
-} from "@clerk/nextjs";
 import Link from "next/link";
-import React, { useEffect } from "react";
-import posthog from "posthog-js";
+import {
+  AnimatedHeading,
+  DigitalDowntown,
+  FadeIn,
+} from "@/components/lr-design/visuals";
+import Nav from "@/components/lr-design/Nav";
 
 export default function Home() {
-  const router = useRouter();
-  const { onboarding, isAppLoaded } = useApp();
-  const { isSignedIn, isLoaded } = useAuth();
-
-  useEffect(() => {
-    if (isLoaded && isSignedIn && isAppLoaded && onboarding.completed) {
-      router.push("/terminal");
-    }
-  }, [isLoaded, isSignedIn, isAppLoaded, onboarding.completed, router]);
   return (
-    <div className="relative min-h-screen">
-      {/* Absolute Header for Login/Dashboard Access */}
-      <div className="absolute top-4 right-4 md:top-8 md:right-8 z-50 flex items-center gap-4">
-        <SignedOut>
-          <Link
-            href="/onboarding"
-            className="text-sm font-medium text-primary-foreground bg-primary hover:brightness-110 px-4 py-2 rounded-full transition-all shadow-[0_0_15px_rgba(114,227,173,0.3)] hover:shadow-[0_0_25px_rgba(114,227,173,0.5)]"
-            onClick={() => posthog.capture("try_for_free_clicked")}
-          >
-            Start for Free
-          </Link>
-          <SignInButton mode="modal">
-            <button
-              className="text-sm font-medium text-foreground/70 hover:text-foreground px-4 py-2 rounded-full border border-border hover:border-primary bg-card/40 backdrop-blur-md transition-all"
-              onClick={() => posthog.capture("sign_in_clicked")}
-            >
-              Sign In
-            </button>
-          </SignInButton>
-        </SignedOut>
-        <SignedIn>
-          <Link
-            href="/terminal"
-            className="text-sm font-medium text-foreground/90 hover:text-foreground px-4 py-2 rounded-full border border-primary/30 hover:border-primary bg-primary/10 backdrop-blur-md transition-all shadow-[0_0_15px_rgba(114,227,173,0.1)] hover:shadow-[0_0_20px_rgba(114,227,173,0.3)] mr-2"
-          >
-            Go to Terminal
-          </Link>
-          <UserButton />
-        </SignedIn>
-      </div>
+    <div
+      className="lr-design"
+      style={{
+        minHeight: "100vh",
+        background: "#000",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Nav />
 
-      {/* Main Waitlist Experience Component */}
-      <WaitlistExperience />
+      <main style={{ flex: 1 }}>
+        <section
+          className="relative w-full"
+          style={{ minHeight: "100vh", overflow: "hidden" }}
+        >
+          <div style={{ position: "absolute", inset: 0 }}>
+            <DigitalDowntown />
+          </div>
+          <div
+            className="px-6 md:px-12 lg:px-16 lg:pb-16 pb-12"
+            style={{
+              position: "relative",
+              minHeight: "100vh",
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "flex-end",
+              zIndex: 20,
+            }}
+          >
+            <div style={{ maxWidth: "52rem" }} className="text-shadow-soft">
+              <AnimatedHeading
+                text={"Build your authentic\ndigital outreach clone."}
+                className="text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-normal mb-6"
+              />
+              <FadeIn delay={1000} duration={1000}>
+                <p
+                  className="text-base md:text-lg mb-8"
+                  style={{
+                    maxWidth: "38rem",
+                    color: "#d1d5db",
+                  }}
+                >
+                  Your conversations & identity stitched into one calm system
+                  that runs while you sleep.
+                </p>
+              </FadeIn>
+              <FadeIn delay={1400} duration={1000}>
+                <div
+                  className="flex flex-wrap"
+                  style={{ gap: "1rem", marginBottom: "1rem" }}
+                >
+                  <Link href="/a16z" className="lr-btn-primary">
+                    Create now!
+                  </Link>
+                </div>
+              </FadeIn>
+              <FadeIn delay={1700} duration={1000}>
+                <p
+                  className="text-sm"
+                  style={{
+                    color: "#9ca3af",
+                    letterSpacing: "0.02em",
+                  }}
+                >
+                  Demo Workflow, beta sign-up in the end.
+                </p>
+              </FadeIn>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer
+        className="px-6 md:px-12 lg:px-16 py-6 flex justify-between"
+        style={{
+          borderTop: "1px solid rgba(255,255,255,0.10)",
+          color: "#d1d5db",
+          fontSize: "0.75rem",
+          flexWrap: "wrap",
+          gap: "0.5rem",
+        }}
+      >
+        <div>LegitReach. Manage real online presence with ease.</div>
+        <a
+          href="mailto:manthan@legitreach.com"
+          style={{ transition: "color 200ms ease" }}
+        >
+          Report Bugs: manthan@legitreach.com
+        </a>
+      </footer>
     </div>
   );
 }

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { Reveal } from "@/components/lr-design/visuals";
+import Nav from "@/components/lr-design/Nav";
+
+type Member = {
+  role: string;
+  name: string;
+  body: string;
+  link?: { label: string; href: string };
+};
+
+const MEMBERS: Member[] = [
+  {
+    role: "Founder + CEO",
+    name: "Manthan Admane",
+    body: "Software developer turned marketing manager at Applied Materials. 2x D2C founder. Owns the product stack, leads fundraising & customer development.",
+    link: { label: "LinkedIn", href: "https://linkedin.com/in/manthanadmane" },
+  },
+  {
+    role: "Founding Engineer",
+    name: "Manas Kalangan",
+    body: "Builds the data pipeline, the inference layer, and the Chrome extension that powers the world model.",
+  },
+  {
+    role: "Research Advisor",
+    name: "Computer Department, MIT-WPU",
+    body: "Co-authored research on AI in marketing. Advises on model architecture and academic validation.",
+  },
+];
+
+function ScrollSection({
+  eyebrow,
+  heading,
+  body,
+}: {
+  eyebrow: string;
+  heading: string;
+  body: string[];
+}) {
+  return (
+    <section className="px-6 md:px-12 lg:px-16 py-32">
+      <div className="max-w-5xl">
+        <Reveal>
+          <div
+            className="text-xs uppercase mb-8"
+            style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+          >
+            {eyebrow}
+          </div>
+        </Reveal>
+        <Reveal delay={120}>
+          <h2
+            className="text-4xl md:text-5xl lg:text-6xl font-normal mb-10 leading-tight"
+            style={{ letterSpacing: "-0.04em", whiteSpace: "pre-line" }}
+          >
+            {heading}
+          </h2>
+        </Reveal>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "1.25rem",
+            maxWidth: "46rem",
+          }}
+        >
+          {body.map((p, i) => (
+            <Reveal key={i} delay={220 + i * 100}>
+              <p
+                className="text-lg md:text-xl leading-relaxed"
+                style={{ whiteSpace: "pre-line", color: "#d1d5db" }}
+              >
+                {p}
+              </p>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function TeamPage() {
+  return (
+    <div
+      className="lr-design"
+      style={{
+        minHeight: "100vh",
+        background: "#000",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <Nav current="/team" />
+
+      <main style={{ flex: 1, paddingTop: "6rem" }}>
+        <section
+          className="px-6 md:px-12 lg:px-16 py-32"
+          style={{ minHeight: "100vh" }}
+        >
+          <div className="max-w-7xl mx-auto" style={{ paddingTop: "4rem" }}>
+            <Reveal>
+              <div
+                className="text-xs uppercase mb-8"
+                style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+              >
+                Team
+              </div>
+            </Reveal>
+            <Reveal delay={120}>
+              <h1
+                className="text-4xl md:text-5xl lg:text-6xl font-normal mb-16 leading-tight"
+                style={{ letterSpacing: "-0.04em" }}
+              >
+                The people behind the model.
+              </h1>
+            </Reveal>
+
+            <div
+              className="md:grid md:grid-cols-3 gap-6"
+              style={{ marginBottom: "5rem" }}
+            >
+              {MEMBERS.map((m, i) => (
+                <Reveal key={i} delay={220 + i * 120}>
+                  <div
+                    className="liquid-glass rounded-xl p-8"
+                    style={{
+                      height: "100%",
+                      border: "1px solid rgba(255,255,255,0.2)",
+                    }}
+                  >
+                    <div
+                      className="text-xs uppercase mb-6"
+                      style={{ letterSpacing: "0.15em", color: "#9ca3af" }}
+                    >
+                      {m.role}
+                    </div>
+                    <h3
+                      className="text-2xl md:text-3xl font-normal mb-5"
+                      style={{ letterSpacing: "-0.03em" }}
+                    >
+                      {m.name}
+                    </h3>
+                    <p
+                      className="text-base leading-relaxed mb-6"
+                      style={{ color: "#d1d5db" }}
+                    >
+                      {m.body}
+                    </p>
+                    {m.link && (
+                      <a
+                        href={m.link.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-sm"
+                        style={{
+                          color: "#fff",
+                          borderBottom: "1px solid rgba(255,255,255,0.3)",
+                          paddingBottom: "2px",
+                          transition: "color 200ms ease",
+                        }}
+                      >
+                        {m.link.label}
+                      </a>
+                    )}
+                  </div>
+                </Reveal>
+              ))}
+            </div>
+
+            <Reveal delay={600}>
+              <div className="text-center">
+                <p
+                  className="text-2xl md:text-3xl font-light mb-4"
+                  style={{ letterSpacing: "-0.02em" }}
+                >
+                  Long term games with long term people.
+                </p>
+                <a
+                  href="mailto:manthan@legitreach.com"
+                  className="text-base md:text-lg"
+                  style={{ color: "#d1d5db", transition: "color 200ms ease" }}
+                >
+                  manthan@legitreach.com
+                </a>
+              </div>
+            </Reveal>
+          </div>
+
+          {/* Founder philosophy */}
+          <div
+            style={{
+              borderTop: "1px solid rgba(255,255,255,0.08)",
+              marginTop: "6rem",
+            }}
+          >
+            <ScrollSection
+              eyebrow="01 / Obsession"
+              heading={"I want to draw\ncapitalism with math."}
+              body={[
+                "I am Manthan. Software developer turned marketer. 2x D2C founder.",
+                "Online interaction is the most valuable function on the internet. Nobody is modeling it from first principles. I am.",
+                "LegitReach is the simulator for online interactions. A sandbox to rehearse the deal before the deal.",
+              ]}
+            />
+
+            <ScrollSection
+              eyebrow="02 / Thesis"
+              heading={"AI made content infinite.\nAttention stayed finite."}
+              body={[
+                "Most companies use AI to make more slop. We use AI to test and predict slop before it ships @ scale.",
+                "Online communities are a platform for trading information (buyer-seller match for data).",
+                "The model knows what gets ignored. The model knows what gets answered. We make the difference measurable.",
+              ]}
+            />
+
+            <ScrollSection
+              eyebrow="03 / The hunting dog"
+              heading={"AI is the hunting dog.\nNot the hunter."}
+              body={[
+                "A dog on a duck hunt does not decide what to shoot. The dog flushes the ducks. The dog retrieves the catch. The hunter holds the gun. The hunter decides when to fire.",
+                "Our agents flush conversations. Our agents draft replies. Our agents predict outcomes. The human approves. Legit tone of voice conversion to post-worthy content. The human owns the relationship.",
+                "Humans always in the loop.",
+              ]}
+            />
+          </div>
+        </section>
+      </main>
+
+      <footer
+        className="px-6 md:px-12 lg:px-16 py-6 flex justify-between"
+        style={{
+          borderTop: "1px solid rgba(255,255,255,0.10)",
+          color: "#d1d5db",
+          fontSize: "0.75rem",
+          flexWrap: "wrap",
+          gap: "0.5rem",
+        }}
+      >
+        <div>LegitReach. Manage real online presence with ease.</div>
+        <a
+          href="mailto:manthan@legitreach.com"
+          style={{ transition: "color 200ms ease" }}
+        >
+          Report Bugs: manthan@legitreach.com
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -14,7 +14,7 @@ export default function AuthHeader() {
   const pathname = usePathname();
 
   // Hide on home page, dashboard, and terminal as they have custom navs
-  if (pathname === '/' || pathname?.startsWith('/dashboard') || pathname?.startsWith('/morning') || pathname?.startsWith('/terminal')) {
+  if (pathname === '/' || pathname?.startsWith('/dashboard') || pathname?.startsWith('/morning') || pathname?.startsWith('/terminal') || pathname?.startsWith('/a16z') || pathname?.startsWith('/invest') || pathname?.startsWith('/building') || pathname?.startsWith('/team')) {
     return null;
   }
 

--- a/src/components/lr-design/Nav.tsx
+++ b/src/components/lr-design/Nav.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+
+const LINKS = [
+  { href: "/invest", label: "Invest" },
+  { href: "/building", label: "Building" },
+  { href: "/team", label: "Team" },
+];
+
+export default function Nav({ current }: { current?: string }) {
+  return (
+    <div
+      className="px-6 md:px-12 lg:px-16 pt-6"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 50,
+      }}
+    >
+      <nav className="liquid-glass rounded-xl px-4 py-2 flex items-center justify-between">
+        <Link
+          href="/"
+          className="text-2xl font-semibold tracking-tight"
+          style={{ letterSpacing: "-0.03em" }}
+        >
+          LegitReach
+        </Link>
+        <div className="hidden md:flex" style={{ gap: "2rem" }}>
+          {LINKS.map((l) => {
+            const active = current === l.href;
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                className="lr-nav-link"
+                style={{
+                  color: active ? "#fff" : "#9ca3af",
+                  borderBottom: active
+                    ? "1px solid rgba(255,255,255,0.6)"
+                    : "1px solid transparent",
+                  paddingBottom: "2px",
+                }}
+              >
+                {l.label}
+              </Link>
+            );
+          })}
+        </div>
+        <a href="mailto:manthan@legitreach.com" className="lr-btn-nav">
+          Start a Chat
+        </a>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/lr-design/visuals.tsx
+++ b/src/components/lr-design/visuals.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+
+export function FadeIn({
+  delay = 0,
+  duration = 1000,
+  children,
+  className = "",
+  style = {},
+}: {
+  delay?: number;
+  duration?: number;
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), delay);
+    return () => clearTimeout(t);
+  }, [delay]);
+  return (
+    <div
+      className={className}
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: visible ? "translateY(0)" : "translateY(8px)",
+        transition: `opacity ${duration}ms ease, transform ${duration}ms ease`,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function AnimatedHeading({
+  text,
+  className = "",
+  style = {},
+}: {
+  text: string;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const [start, setStart] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setStart(true), 200);
+    return () => clearTimeout(t);
+  }, [text]);
+  const lines = text.split("\n");
+  const charDelay = 30;
+  return (
+    <h1 className={className} style={{ letterSpacing: "-0.04em", ...style }}>
+      {lines.map((line, li) => (
+        <span key={li} style={{ display: "block" }}>
+          {Array.from(line).map((ch, ci) => {
+            const d = li * line.length * charDelay + ci * charDelay;
+            return (
+              <span
+                key={ci}
+                style={{
+                  display: "inline-block",
+                  opacity: start ? 1 : 0,
+                  transform: start ? "translateX(0)" : "translateX(-18px)",
+                  transition: `opacity 500ms ease ${d}ms, transform 500ms ease ${d}ms`,
+                  whiteSpace: "pre",
+                }}
+              >
+                {ch === " " ? " " : ch}
+              </span>
+            );
+          })}
+        </span>
+      ))}
+    </h1>
+  );
+}
+
+export function Reveal({
+  children,
+  className = "",
+  delay = 0,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [vis, setVis] = useState(false);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([e]) => {
+        if (e.isIntersecting) {
+          setTimeout(() => setVis(true), delay);
+          io.disconnect();
+        }
+      },
+      { threshold: 0.15 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [delay]);
+  return (
+    <div
+      ref={ref}
+      className={`reveal ${vis ? "is-visible" : ""} ${className}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+function DataPackets() {
+  const packets = Array.from({ length: 18 }).map((_, i) => {
+    const startX = (10 + i * 53) % 90;
+    const startY = (55 + i * 17) % 35;
+    const dx = (i % 2 === 0 ? 1 : -1) * (10 + (i * 7) % 25);
+    const dy = -(8 + (i * 11) % 20);
+    const dur = 5 + (i % 6);
+    const delay = (i * 0.6) % 8;
+    return { startX, startY, dx, dy, dur, delay, i };
+  });
+  return (
+    <div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+      {packets.map((p) => (
+        <div
+          key={p.i}
+          style={{
+            position: "absolute",
+            left: `${p.startX}%`,
+            top: `${p.startY}%`,
+            width: 4,
+            height: 4,
+            background: "#fff",
+            borderRadius: "50%",
+            boxShadow: "0 0 6px rgba(255,255,255,0.8)",
+            ["--dx" as string]: `${p.dx}vw`,
+            ["--dy" as string]: `${p.dy}vh`,
+            animation: `lr-pulse-dot ${p.dur}s ease-in-out ${p.delay}s infinite`,
+            opacity: 0,
+          } as React.CSSProperties}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function DigitalDowntown() {
+  return (
+    <div className="scene">
+      <div className="scene-bg" />
+      <div className="scene-stars" />
+      <div className="scene-floor" />
+      <div className="scene-haze" />
+
+      <svg
+        viewBox="0 0 1600 900"
+        preserveAspectRatio="xMidYMax slice"
+        style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+      >
+        <defs>
+          <linearGradient id="lr-building" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#0d0d0d" />
+            <stop offset="100%" stopColor="#000" />
+          </linearGradient>
+          <linearGradient id="lr-buildingFront" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#161616" />
+            <stop offset="100%" stopColor="#000" />
+          </linearGradient>
+        </defs>
+
+        <g opacity="0.45">
+          {(
+            [
+              [0, 540, 90, 160], [90, 500, 60, 200], [150, 520, 80, 180],
+              [230, 480, 70, 220], [300, 530, 100, 170], [400, 470, 60, 230],
+              [460, 510, 90, 190], [550, 460, 70, 240], [620, 500, 80, 200],
+              [700, 490, 70, 210], [770, 520, 110, 180], [880, 470, 80, 230],
+              [960, 510, 70, 190], [1030, 480, 90, 220], [1120, 520, 80, 180],
+              [1200, 470, 100, 230], [1300, 500, 70, 200], [1370, 530, 90, 170],
+              [1460, 490, 80, 210], [1540, 520, 60, 180],
+            ] as Array<[number, number, number, number]>
+          ).map(([x, y, w, h], i) => (
+            <rect key={i} x={x} y={y} width={w} height={h} fill="url(#lr-building)" />
+          ))}
+        </g>
+
+        <g opacity="0.85">
+          {(
+            [
+              [-20, 470, 110, 240], [90, 430, 80, 280], [170, 460, 130, 250],
+              [300, 410, 90, 300], [390, 450, 110, 260], [500, 400, 80, 310],
+              [580, 440, 120, 270], [700, 420, 90, 290], [790, 460, 110, 250],
+              [900, 410, 100, 300], [1000, 440, 130, 270], [1130, 420, 90, 290],
+              [1220, 460, 110, 250], [1330, 410, 100, 300], [1430, 440, 90, 270],
+              [1520, 470, 110, 240],
+            ] as Array<[number, number, number, number]>
+          ).map(([x, y, w, h], i) => (
+            <rect key={i} x={x} y={y} width={w} height={h} fill="url(#lr-building)" />
+          ))}
+          {Array.from({ length: 220 }).map((_, i) => {
+            const x = 20 + (i * 73) % 1560;
+            const y = 470 + (i * 37) % 240;
+            const op = 0.15 + ((i * 13) % 70) / 100;
+            return <rect key={i} x={x} y={y} width={3} height={3} fill="#ffffff" opacity={op} />;
+          })}
+        </g>
+
+        {/* central hero building */}
+        <g>
+          <rect x={720} y={300} width={180} height={500} fill="url(#lr-buildingFront)" />
+          <rect x={720} y={300} width={180} height={4} fill="#fff" opacity="0.25" />
+          <rect x={805} y={230} width={10} height={70} fill="url(#lr-buildingFront)" />
+          <rect x={808} y={210} width={4} height={20} fill="#fff" opacity="0.4" />
+          {Array.from({ length: 14 }).map((_, r) =>
+            Array.from({ length: 7 }).map((__, c) => {
+              const x = 735 + c * 22;
+              const y = 320 + r * 32;
+              const seed = r * 7 + c;
+              const on = seed % 5 === 0 || seed % 7 === 0;
+              const flicker = seed % 13 === 0;
+              return (
+                <rect
+                  key={`${r}-${c}`}
+                  x={x}
+                  y={y}
+                  width={10}
+                  height={14}
+                  fill="#ffffff"
+                  opacity={on ? 0.55 : 0.08}
+                  className={flicker ? `blink blink-${(seed % 4) + 1}` : ""}
+                />
+              );
+            })
+          )}
+        </g>
+
+        <g>
+          <rect x={520} y={360} width={130} height={440} fill="url(#lr-buildingFront)" />
+          <rect x={520} y={360} width={130} height={3} fill="#fff" opacity="0.18" />
+          {Array.from({ length: 12 }).map((_, r) =>
+            Array.from({ length: 5 }).map((__, c) => {
+              const x = 535 + c * 22;
+              const y = 380 + r * 32;
+              const seed = r * 5 + c + 99;
+              const on = seed % 4 === 0;
+              const flicker = seed % 11 === 0;
+              return (
+                <rect
+                  key={`b-${r}-${c}`}
+                  x={x}
+                  y={y}
+                  width={10}
+                  height={14}
+                  fill="#fff"
+                  opacity={on ? 0.5 : 0.08}
+                  className={flicker ? `blink blink-${(seed % 4) + 1}` : ""}
+                />
+              );
+            })
+          )}
+        </g>
+
+        <g>
+          <rect x={950} y={380} width={150} height={420} fill="url(#lr-buildingFront)" />
+          <rect x={950} y={380} width={150} height={3} fill="#fff" opacity="0.18" />
+          {Array.from({ length: 12 }).map((_, r) =>
+            Array.from({ length: 6 }).map((__, c) => {
+              const x = 965 + c * 22;
+              const y = 400 + r * 30;
+              const seed = r * 6 + c + 211;
+              const on = seed % 4 === 0;
+              const flicker = seed % 9 === 0;
+              return (
+                <rect
+                  key={`c-${r}-${c}`}
+                  x={x}
+                  y={y}
+                  width={10}
+                  height={14}
+                  fill="#fff"
+                  opacity={on ? 0.55 : 0.08}
+                  className={flicker ? `blink blink-${(seed % 4) + 1}` : ""}
+                />
+              );
+            })
+          )}
+        </g>
+
+        <g>
+          <rect x={350} y={500} width={120} height={300} fill="url(#lr-buildingFront)" />
+          <rect x={1140} y={490} width={120} height={310} fill="url(#lr-buildingFront)" />
+          <rect x={1280} y={520} width={100} height={280} fill="url(#lr-buildingFront)" />
+          <rect x={200} y={520} width={110} height={280} fill="url(#lr-buildingFront)" />
+        </g>
+
+        <rect x="0" y="540" width="1600" height="2" fill="#fff" opacity="0.12" />
+
+        <g opacity="0.18">
+          <line x1="810" y1="210" x2="810" y2="0" stroke="#fff" strokeWidth="1" />
+          <line x1="585" y1="360" x2="585" y2="0" stroke="#fff" strokeWidth="0.7" />
+          <line x1="1025" y1="380" x2="1025" y2="0" stroke="#fff" strokeWidth="0.7" />
+        </g>
+      </svg>
+
+      <DataPackets />
+    </div>
+  );
+}
+
+export function Backdrop() {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+      }}
+    >
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background:
+            "radial-gradient(ellipse at 50% 95%, #0c0c0c 0%, #000 60%)",
+        }}
+      />
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          right: 0,
+          bottom: 0,
+          height: "55%",
+          background: `
+            linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.75) 80%, #000 100%),
+            repeating-linear-gradient(to right, rgba(255,255,255,0.05) 0 1px, transparent 1px 70px),
+            repeating-linear-gradient(to bottom, rgba(255,255,255,0.05) 0 1px, transparent 1px 70px)`,
+          transform: "perspective(900px) rotateX(64deg)",
+          transformOrigin: "bottom",
+          opacity: 0.7,
+        }}
+      />
+      <svg
+        viewBox="0 0 1600 900"
+        preserveAspectRatio="xMidYMax slice"
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          opacity: 0.5,
+        }}
+      >
+        <defs>
+          <linearGradient id="lr-bld" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#0e0e0e" />
+            <stop offset="100%" stopColor="#000" />
+          </linearGradient>
+        </defs>
+        {(
+          [
+            [0, 640, 110, 200], [110, 600, 70, 240], [180, 620, 120, 220], [300, 580, 80, 260],
+            [380, 610, 110, 230], [490, 570, 90, 270], [580, 600, 130, 240], [710, 580, 80, 260],
+            [790, 620, 110, 220], [900, 580, 90, 260], [990, 610, 130, 230], [1120, 590, 80, 250],
+            [1200, 620, 110, 220], [1310, 580, 90, 260], [1400, 610, 130, 230], [1530, 640, 90, 200],
+          ] as Array<[number, number, number, number]>
+        ).map(([x, y, w, h], i) => (
+          <rect key={i} x={x} y={y} width={w} height={h} fill="url(#lr-bld)" />
+        ))}
+        {Array.from({ length: 120 }).map((_, i) => {
+          const x = 20 + (i * 97) % 1560;
+          const y = 600 + (i * 37) % 240;
+          return (
+            <rect
+              key={i}
+              x={x}
+              y={y}
+              width={2}
+              height={2}
+              fill="#fff"
+              opacity={0.2 + (i % 5) * 0.07}
+            />
+          );
+        })}
+        <rect x="0" y="640" width="1600" height="1" fill="#fff" opacity="0.08" />
+      </svg>
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background:
+            "radial-gradient(ellipse at center, transparent 30%, rgba(0,0,0,0.55) 100%)",
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the public-facing landing page and adds the full investor site under the LegitReach design system (`lr-design`).

- **New landing** ([src/app/page.tsx](src/app/page.tsx)) — black hero with `DigitalDowntown` animated cityscape, "Build your authentic digital outreach clone." headline, `Create now!` CTA → `/a16z` demo, subline "Demo Workflow, beta sign-up in the end."
- **`/a16z`** — guided onboarding walkthrough that ends on a control-room dashboard with the line "Demo workflow completed. You can access the beta by clicking here." → `/beta`.
- **`/beta`** — preserved existing waitlist experience.
- **`/invest`** — vision hero, Today/Planned cards, active pre-seed round, and a full-screen pitch-deck iframe overlay (Escape / backdrop / Download-PDF). Deck served as static HTML from `/public/pitch-deck.html` + `/public/deck-stage.js`.
- **`/building`** — "Live today" (3 paying customers · $600 MRR · 5 min/day) and "Coming next" (Full Power simulator, education LOI).
- **`/team`** — founder + founding engineer + MIT-WPU research advisor cards, plus the Obsession / Thesis / Hunting-Dog philosophy sections.
- **Shared chrome** — new `<Nav>` ([src/components/lr-design/Nav.tsx](src/components/lr-design/Nav.tsx)) with Invest / Building / Team links and active-state underline; `<AuthHeader>` hidden on all new design routes so each page owns its nav.
- **Design system** — `lr-design` CSS namespace added to [globals.css](src/app/globals.css) so the new black theme doesn't conflict with the existing green app shell. Animated primitives (`AnimatedHeading`, `DigitalDowntown`, `FadeIn`, `Reveal`) live in [src/components/lr-design/visuals.tsx](src/components/lr-design/visuals.tsx).

## Why

The previous landing was the green app shell. Investors and inbound visitors now land on a coherent narrative: demo the product (`/a16z`), then dive into the story (`/invest`, `/building`, `/team`).

## Test plan

- [ ] `/` renders the new black hero; "Create now!" routes to `/a16z`
- [ ] `/a16z` walkthrough completes and the dashboard footer link routes to `/beta`
- [ ] `/invest` — "Pitch deck" button opens the iframe overlay; Escape and backdrop both close it; Download PDF triggers print
- [ ] `/building` and `/team` render with shared `Nav` and active-link underline
- [ ] AuthHeader is hidden on `/`, `/a16z`, `/invest`, `/building`, `/team` (and unchanged elsewhere)
- [ ] Existing green-themed routes (dashboard, terminal, etc.) are visually unaffected by the `lr-design` namespace additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)