### PR TITLE
Boston Tech Week: pricing refresh, launch-flow routing, deck mobile fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@upstash/realtime": "^1.0.3",
     "@upstash/redis": "^1.36.2",
     "cheerio": "^1.2.0",
-    "exa-js": "^2.13.0",
     "lucide-react": "^0.575.0",
     "next": "16.1.6",
     "next-auth": "^4.24.13",

--- a/public/launch/src/Terminal.jsx
+++ b/public/launch/src/Terminal.jsx
@@ -1104,7 +1104,7 @@ function TourHighlight({ step, total, onNext, onSkip, last }) {
 const tourStyles = {
   frame:{ position:"absolute", inset:-2, pointerEvents:"none", zIndex:4 },
   ring:{ position:"absolute", inset:0, border:"1px solid #3f9c6a", boxShadow:"0 0 0 1px rgba(63,156,106,.35), 0 0 32px rgba(63,156,106,.32), inset 0 0 18px rgba(63,156,106,.10)", animation:"lrTourPulse 1.8s ease-in-out infinite" },
-  tip:{ position:"absolute", bottom:-12, right:12, transform:"translateY(100%)", display:"inline-flex", alignItems:"center", gap:12, padding:"8px 12px 8px 14px", background:"#040404", border:"1px solid #3f9c6a", color:"#fff", pointerEvents:"auto", boxShadow:"0 8px 24px rgba(0,0,0,.55)" },
+  tip:{ position:"absolute", top:-12, right:12, transform:"translateY(-100%)", display:"inline-flex", alignItems:"center", gap:12, padding:"8px 12px 8px 14px", background:"#040404", border:"1px solid #3f9c6a", color:"#fff", pointerEvents:"auto", boxShadow:"0 8px 24px rgba(0,0,0,.55)" },
   tipCount:{ fontSize:10, color:"#5cd197", letterSpacing:"0.22em" },
   tipBtns:{ display:"inline-flex", gap:6 },
   tipSkip:{ background:"transparent", border:"none", color:"#666", fontSize:10, letterSpacing:"0.18em", padding:"6px 8px", cursor:"pointer" },
@@ -1704,17 +1704,23 @@ const bpStyles = {
 // Minimal top-up. Three tiers, payment-method row. Built to convince, not overwhelm.
 
 const CREDIT_TIERS = [
-{ id: "starter", price: 49, credits: 49, perCredit: 1.00 },
-{ id: "growth", price: 99, credits: 100, perCredit: 0.99, popular: true },
-{ id: "scale", price: 199, credits: 250, perCredit: 0.80, best: true }];
+{ id: "monthly", price: 29, term: "30 days", credits: 50, note: "billed monthly" },
+{ id: "quarterly", price: 79, term: "90 days", credits: 180, note: "3 months — best value", popular: true },
+{ id: "enterprise", contact: true, term: "custom", note: "large brands & research orgs" }];
+
+const ENTERPRISE_EMAIL = "direct@legitreach.com";
 
 
 function CreditsModal({ credits, onTopUp, onClose }) {
-  const [selected, setSelected] = useStateT("growth");
+  const [selected, setSelected] = useStateT("quarterly");
   const [stage, setStage] = useStateT("pick"); // pick → paying → done
   const tier = CREDIT_TIERS.find((t) => t.id === selected);
 
   function pay() {
+    if (tier.contact) {
+      window.location.href = `mailto:${ENTERPRISE_EMAIL}?subject=${encodeURIComponent("LegitReach Enterprise")}`;
+      return;
+    }
     setStage("paying");
     setTimeout(() => {
       onTopUp(tier.credits);
@@ -1728,14 +1734,14 @@ function CreditsModal({ credits, onTopUp, onClose }) {
       <div style={creditsStyles.dialog} className="lr-credits-dialog" onClick={(e) => e.stopPropagation()}>
         <header style={creditsStyles.header} className="lr-modal-header">
           <div>
-            <h3 style={creditsStyles.title}>Top up credits</h3>
+            <h3 style={creditsStyles.title}>Choose your plan</h3>
             <div className="mono" style={creditsStyles.balance}>balance · {credits} credits</div>
           </div>
           <button onClick={onClose} style={creditsStyles.close} className="mono">esc</button>
         </header>
 
         <div style={creditsStyles.body} className="lr-credits-body">
-          <div className="mono" style={creditsStyles.fieldLabel}>choose a package</div>
+          <div className="mono" style={creditsStyles.fieldLabel}>choose a plan</div>
           <div style={creditsStyles.tiers} className="lr-credits-tiers">
             {CREDIT_TIERS.map((t) => {
               const isSelected = selected === t.id;
@@ -1746,12 +1752,11 @@ function CreditsModal({ credits, onTopUp, onClose }) {
                   background: isSelected ? "#0d0d0d" : "transparent"
                 }} className="lr-credits-tier">
                   <div style={creditsStyles.tierTop}>
-                    <span style={creditsStyles.tierPrice}>${t.price}</span>
-                    {t.popular && <span style={creditsStyles.tierBadgePop} className="mono">popular</span>}
-                    {t.best && <span style={creditsStyles.tierBadgeBest} className="mono">best value</span>}
+                    <span style={creditsStyles.tierPrice}>{t.contact ? "Contact" : `$${t.price}`}</span>
+                    {t.popular && <span style={creditsStyles.tierBadgeBest} className="mono">best value</span>}
                   </div>
-                  <div style={creditsStyles.tierCredits}>{t.credits} credits</div>
-                  <div className="mono" style={creditsStyles.tierPer}>${t.perCredit.toFixed(2)} / credit</div>
+                  <div style={creditsStyles.tierCredits}>{t.term}</div>
+                  <div className="mono" style={creditsStyles.tierPer}>{t.note}</div>
                   <div style={{ ...creditsStyles.tierCheck, opacity: isSelected ? 1 : 0 }}>●</div>
                 </button>);
 
@@ -1774,7 +1779,8 @@ function CreditsModal({ credits, onTopUp, onClose }) {
 
         <footer style={creditsStyles.footer} className="lr-modal-footer">
           <span className="mono" style={creditsStyles.footerMeta}>
-            {stage === "done" ? `+${tier.credits} added · new balance ${credits + tier.credits}` :
+            {tier.contact ? `talk to us · ${ENTERPRISE_EMAIL}` :
+            stage === "done" ? `+${tier.credits} added · new balance ${credits + tier.credits}` :
             stage === "paying" ? `charging $${tier.price.toFixed(2)}…` :
             `you'll be charged $${tier.price.toFixed(2)}`}
           </span>
@@ -1783,9 +1789,10 @@ function CreditsModal({ credits, onTopUp, onClose }) {
             background: stage === "done" ? "#1a1a1a" : "#fff",
             color: stage === "done" ? "#fff" : "#000"
           }} onClick={pay} disabled={stage !== "pick"} className="lr-credits-pay">
-            {stage === "done" ? <>added <span>✓</span></> :
+            {tier.contact ? <>contact us <span>→</span></> :
+            stage === "done" ? <>activated <span>✓</span></> :
             stage === "paying" ? <>charging…</> :
-            <>buy {tier.credits} credits <span>→</span></>}
+            <>start {tier.term} <span>→</span></>}
           </button>
         </footer>
       </div>

--- a/public/pitch-deck.html
+++ b/public/pitch-deck.html
@@ -9,6 +9,8 @@
 <style>
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
+:root { --slide-w: 1280px; --slide-h: 720px; --s: 1; }
+
 html { scroll-snap-type: y mandatory; scroll-behavior: smooth; }
 body {
   background: #000; color: #fff;
@@ -17,24 +19,35 @@ body {
   overflow-x: hidden; overflow-y: scroll;
 }
 
+/* Each slide lives on a full-viewport page that centers and scales the
+   fixed 16:9 canvas. Same composition on phone and desktop — the whole
+   slide always fits the screen (letterboxed), and you pinch-zoom to read. */
+.page {
+  height: 100vh; width: 100%;
+  display: flex; align-items: center; justify-content: center;
+  scroll-snap-align: start; overflow: hidden;
+}
+
 .slide {
-  height: 100vh; scroll-snap-align: start;
-  padding: 96px 100px 80px;
+  width: var(--slide-w); height: var(--slide-h);
+  flex: none;
+  transform: scale(var(--s)); transform-origin: center center;
+  padding: 64px 84px;
   display: flex; flex-direction: column; justify-content: center;
   position: relative; overflow: hidden;
-  border-bottom: 1px solid #0f0f0f;
+  background: #000; border: 1px solid #0f0f0f;
 }
 
 .bg { position: absolute; inset: 0; z-index: 0; pointer-events: none; }
 
 #logo {
-  position: fixed; top: 32px; left: 80px;
+  position: fixed; top: 28px; left: 28px;
   font-size: 13px; font-weight: 700; letter-spacing: 0.04em;
   color: #fff; z-index: 300;
 }
 
 #nav-dots {
-  position: fixed; right: 24px; top: 50%; transform: translateY(-50%);
+  position: fixed; right: 16px; top: 50%; transform: translateY(-50%);
   display: flex; flex-direction: column; gap: 8px; z-index: 300;
 }
 .dot {
@@ -50,39 +63,39 @@ body {
 }
 
 h1 {
-  font-size: clamp(50px, 6.4vw, 86px);
+  font-size: 76px;
   font-weight: 900; line-height: 1.04; letter-spacing: -0.03em;
   max-width: 860px; position: relative; z-index: 1; color: #fff;
 }
 h2 {
-  font-size: clamp(36px, 4.2vw, 58px);
+  font-size: 52px;
   font-weight: 700; line-height: 1.1; letter-spacing: -0.025em;
   max-width: 760px; position: relative; z-index: 1; color: #fff;
 }
 .body {
-  font-size: clamp(17px, 1.75vw, 21px); line-height: 1.65;
+  font-size: 20px; line-height: 1.65;
   color: #bbb; max-width: 640px; margin-top: 24px;
   position: relative; z-index: 1;
 }
 .body + .body { margin-top: 14px; }
 
 .pdf-btn {
-  position: absolute; top: 32px; right: 80px; z-index: 2;
-  background: none; border: 1px solid #222; color: #777;
-  font-family: inherit; font-size: 10px; letter-spacing: 0.12em;
-  text-transform: uppercase; padding: 9px 18px;
+  position: fixed; top: 24px; right: 24px; z-index: 300;
+  background: #000; border: 1px solid #333; color: #aaa;
+  font-family: inherit; font-size: 11px; letter-spacing: 0.12em;
+  text-transform: uppercase; padding: 10px 18px;
   cursor: pointer; transition: all 0.2s;
 }
-.pdf-btn:hover { border-color: #555; color: #fff; }
+.pdf-btn:hover { border-color: #777; color: #fff; }
 
 /* COVER */
 #s1 .safe-line {
   font-size: 13px; color: #fff; letter-spacing: 0.06em;
   margin-bottom: 28px; position: relative; z-index: 1;
 }
-#s1 h1 { font-size: clamp(68px, 9vw, 110px); }
+#s1 h1 { font-size: 104px; }
 #s1 .tagline {
-  font-size: clamp(16px, 1.9vw, 22px); font-weight: 300;
+  font-size: 21px; font-weight: 300;
   color: #888; margin-top: 16px; letter-spacing: -0.01em;
   position: relative; z-index: 1;
 }
@@ -98,7 +111,7 @@ h2 {
   padding-top: 26px; max-width: 560px; position: relative; z-index: 1;
 }
 .disc-n {
-  font-size: clamp(50px, 6vw, 74px); font-weight: 900;
+  font-size: 64px; font-weight: 900;
   letter-spacing: -0.05em; line-height: 1; color: #fff;
 }
 .disc-l { font-size: 15px; color: #999; margin-top: 8px; line-height: 1.5; }
@@ -137,7 +150,7 @@ h2 {
 .metric { padding: 34px 30px; border-right: 1px solid #141414; }
 .metric:last-child { border-right: none; }
 .metric-n {
-  font-size: clamp(52px, 5.5vw, 74px); font-weight: 900;
+  font-size: 66px; font-weight: 900;
   letter-spacing: -0.05em; line-height: 1; color: #fff;
 }
 .metric-l { font-size: 15px; color: #aaa; margin-top: 10px; line-height: 1.5; }
@@ -220,30 +233,34 @@ h2 {
 /* CLOSE */
 #s11 { justify-content: flex-end; padding-bottom: 100px; }
 #s11 .close-try {
-  display: block; font-size: clamp(32px, 4vw, 58px); font-weight: 900;
+  display: block; font-size: 52px; font-weight: 900;
   letter-spacing: -0.03em; color: #fff;
   text-decoration: underline; text-underline-offset: 10px;
   margin-bottom: 48px; position: relative; z-index: 1;
 }
 #s11 .close-label { font-size: 15px; color: #555; margin-bottom: 10px; position: relative; z-index: 1; }
 #s11 .close-email {
-  font-size: clamp(26px, 3.8vw, 52px); font-weight: 900;
+  font-size: 46px; font-weight: 900;
   letter-spacing: -0.03em; color: #fff;
   text-decoration: underline; text-underline-offset: 8px;
   position: relative; z-index: 1;
 }
 #s11 .close-site { font-size: 13px; color: #333; margin-top: 10px; position: relative; z-index: 1; }
 
-/* PRINT */
+/* PRINT — one full 16:9 slide per page, unscaled, so the PDF is a proper deck */
 @media print {
   * { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-  @page { size: landscape; margin: 0; }
+  @page { size: 1280px 720px; margin: 0; }
   html { scroll-snap-type: none; }
-  body { overflow: visible; }
-  .slide {
-    height: 100vh;
+  body { overflow: visible; background: #000; }
+  .page {
+    height: auto; width: auto; display: block; overflow: visible;
     page-break-after: always; break-after: page;
-    scroll-snap-align: none; overflow: hidden;
+  }
+  .slide {
+    width: 1280px; height: 720px;
+    transform: none; border: none;
+    overflow: hidden;
   }
   .bg { display: none; }
   #logo, #nav-dots, .pdf-btn { display: none !important; }
@@ -253,6 +270,7 @@ h2 {
 <body>
 
 <div id="logo">LegitReach</div>
+<button class="pdf-btn" onclick="window.print()">Download PDF</button>
 <div id="nav-dots"></div>
 
 <div id="deck">
@@ -265,7 +283,6 @@ h2 {
     <circle cx="1150" cy="450" r="140" fill="none" stroke="#0c0c0c" stroke-width="1"/>
     <circle cx="1150" cy="450" r="40"  fill="none" stroke="#0b0b0b" stroke-width="1"/>
   </svg>
-  <button class="pdf-btn" onclick="window.print()">Download PDF</button>
   <div class="safe-line">Pre-Seed · SAFE · Closing 23 Jun 2026</div>
   <h1>LegitReach</h1>
   <div class="tagline">Simple-automations to manage your online-community.</div>
@@ -468,16 +485,16 @@ h2 {
   <h1>Simple pricing.<br>Zero ad spend.</h1>
   <div class="pricing-top">
     <div class="plan">
-      <div class="plan-name">Solo</div>
-      <div class="plan-price">$49<span class="unit">/mo</span></div>
+      <div class="plan-name">Monthly</div>
+      <div class="plan-price">$29<span class="unit">/30 days</span></div>
       <div class="plan-for">Brand owners and solopreneurs</div>
-      <div class="plan-desc">The core tool. Signal detection.</div>
+      <div class="plan-desc">The full tool. Signal detection and AI-assisted drafting, billed monthly.</div>
     </div>
     <div class="plan">
-      <div class="plan-name">Community Manager</div>
-      <div class="plan-price">$99<span class="unit">/mo</span></div>
-      <div class="plan-for">Teams managing brand voice</div>
-      <div class="plan-desc">Tool plus AI-assisted automations.</div>
+      <div class="plan-name">Quarterly</div>
+      <div class="plan-price">$79<span class="unit">/90 days</span></div>
+      <div class="plan-for">Best value — three months up front</div>
+      <div class="plan-desc">Everything in Monthly for 90 days. Save versus paying month to month.</div>
     </div>
   </div>
   <div class="enterprise-box">
@@ -527,33 +544,52 @@ h2 {
 </div>
 
 <script>
-  const slides = document.querySelectorAll('.slide');
+  const deck = document.getElementById('deck');
+  const slides = Array.from(document.querySelectorAll('.slide'));
   const dotsEl = document.getElementById('nav-dots');
 
-  slides.forEach((s, i) => {
+  // Wrap each fixed-canvas slide in a full-viewport page that centers it.
+  const pages = slides.map(s => {
+    const page = document.createElement('div');
+    page.className = 'page';
+    page.dataset.label = s.dataset.label || '';
+    deck.insertBefore(page, s);
+    page.appendChild(s);
+    return page;
+  });
+
+  // Scale the 1280x720 canvas to fully fit the viewport (contain).
+  function fit() {
+    const s = Math.min(window.innerWidth / 1280, window.innerHeight / 720);
+    document.documentElement.style.setProperty('--s', String(s));
+  }
+  window.addEventListener('resize', fit);
+  window.addEventListener('orientationchange', fit);
+  fit();
+
+  pages.forEach((p) => {
     const d = document.createElement('div');
     d.className = 'dot';
-    d.title = s.dataset.label || '';
-    d.addEventListener('click', () => s.scrollIntoView({ behavior: 'smooth' }));
+    d.title = p.dataset.label;
+    d.addEventListener('click', () => p.scrollIntoView({ behavior: 'smooth' }));
     dotsEl.appendChild(d);
   });
 
   const io = new IntersectionObserver(entries => {
     entries.forEach(e => {
       if (e.isIntersecting && e.intersectionRatio >= 0.5) {
-        const idx = Array.from(slides).indexOf(e.target);
+        const idx = pages.indexOf(e.target);
         dotsEl.querySelectorAll('.dot').forEach((d, i) => d.classList.toggle('active', i === idx));
       }
     });
   }, { threshold: 0.5 });
 
-  slides.forEach(s => io.observe(s));
+  pages.forEach(p => io.observe(p));
 
   document.addEventListener('keydown', e => {
-    const all = Array.from(slides);
-    const cur = all.findIndex(s => Math.abs(s.getBoundingClientRect().top) < 50);
-    if (e.key === 'ArrowDown' && cur < all.length - 1) all[cur + 1].scrollIntoView({ behavior: 'smooth' });
-    if (e.key === 'ArrowUp' && cur > 0) all[cur - 1].scrollIntoView({ behavior: 'smooth' });
+    const cur = pages.findIndex(p => Math.abs(p.getBoundingClientRect().top) < 50);
+    if (e.key === 'ArrowDown' && cur < pages.length - 1) pages[cur + 1].scrollIntoView({ behavior: 'smooth' });
+    if (e.key === 'ArrowUp' && cur > 0) pages[cur - 1].scrollIntoView({ behavior: 'smooth' });
   });
 </script>
 </body>

--- a/src/app/api/tech-week/magic-scan/route.ts
+++ b/src/app/api/tech-week/magic-scan/route.ts
@@ -169,8 +169,7 @@ List exactly 4 real, currently active subreddits. Format each one as r/subreddit
 }
 
 async function discoverCommunities(
-  brand: BrandProfile,
-  _storeUrl: string
+  brand: BrandProfile
 ): Promise<string[]> {
   return discoverCommunitiesViaGeminiGrounded(brand);
 }

--- a/src/app/api/tech-week/magic-scan/route.ts
+++ b/src/app/api/tech-week/magic-scan/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import Exa from "exa-js";
 import { getGeminiModel } from "@/ai/gemini.model";
 import { ProxyAgent, fetch as proxyFetch } from "undici";
 
-// Sequential steps: Jina ~3s + Gemini ~4s + Exa parallel ~3s + rules parallel ~3s + Gemini ~4s
+// Sequential steps: Jina ~3s + Gemini ~4s + Gemini discovery ~3s + rules parallel ~3s + Gemini ~4s
 export const maxDuration = 45;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -114,64 +113,7 @@ Return only the JSON. No markdown. No explanation.`;
   return JSON.parse(raw) as BrandProfile;
 }
 
-// ─── Step 3: Exa — discover real active communities ───────────────────────────
-
-function extractSubreddits(urls: string[]): string[] {
-  const counts = new Map<string, number>();
-  for (const url of urls) {
-    const match = url.match(/reddit\.com\/r\/([a-zA-Z0-9_]+)/i);
-    if (match) {
-      const sub = match[1].toLowerCase();
-      // Skip generic/catch-all subs that aren't useful
-      if (!["reddit", "all", "popular", "home", "search"].includes(sub)) {
-        counts.set(sub, (counts.get(sub) || 0) + 1);
-      }
-    }
-  }
-  return [...counts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([sub]) => sub)
-    .slice(0, 4); // top 4 by frequency
-}
-
-async function discoverCommunitiesViaExa(
-  brand: BrandProfile,
-  storeUrl: string
-): Promise<string[]> {
-  const exa = new Exa(process.env.EXA_API_KEY!);
-
-  // Keep queries short and natural — Exa neural search works better with concise prompts
-  const problemQuery = brand.buyerProblems[0] ?? brand.keywords[0] ?? brand.businessDescription.slice(0, 60);
-  const categoryQuery = brand.productCategories[0] ?? brand.keywords[0];
-
-  const [problemRes, categoryRes, urlRes] = await Promise.allSettled([
-    exa.search(`${problemQuery} advice reddit`, {
-      type: "neural",
-      includeDomains: ["reddit.com"],
-      numResults: 5,
-    }),
-    exa.search(`best ${categoryQuery} recommendations reddit`, {
-      type: "neural",
-      includeDomains: ["reddit.com"],
-      numResults: 5,
-    }),
-    // Store URL as semantic anchor — finds Reddit content similar to the brand
-    exa.search(storeUrl, {
-      type: "neural",
-      includeDomains: ["reddit.com"],
-      numResults: 5,
-    }),
-  ]);
-
-  const allUrls: string[] = [];
-  for (const res of [problemRes, categoryRes, urlRes]) {
-    if (res.status === "fulfilled") {
-      allUrls.push(...res.value.results.map((r) => r.url));
-    }
-  }
-
-  return extractSubreddits(allUrls);
-}
+// ─── Step 3: Gemini — discover relevant active communities ────────────────────
 
 async function discoverCommunitiesViaGemini(brand: BrandProfile): Promise<string[]> {
   const prompt = `You are a Reddit expert. Based on this brand profile, suggest the 4 most relevant subreddits where the target audience actively discusses problems this brand solves.
@@ -193,19 +135,9 @@ Example: ["Parenting", "beyondthebump", "daddit", "InfantRearing"]`;
 }
 
 async function discoverCommunities(
-  brand: BrandProfile,
-  storeUrl: string
+  brand: BrandProfile
 ): Promise<string[]> {
-  // Try Exa first — returns real, live communities
-  const exaCandidates = await discoverCommunitiesViaExa(brand, storeUrl);
-
-  if (exaCandidates.length > 0) {
-    console.log("[magic-scan] Exa found candidates:", exaCandidates);
-    return exaCandidates;
-  }
-
-  // Fallback to Gemini — still grounded because rules are fetched in Step 4
-  console.log("[magic-scan] Exa returned 0 candidates — falling back to Gemini suggestions");
+  // Gemini suggestions — grounded because actual rules are fetched in Step 4
   const geminiCandidates = await discoverCommunitiesViaGemini(brand);
   console.log("[magic-scan] Gemini suggested:", geminiCandidates);
   return geminiCandidates;
@@ -413,7 +345,7 @@ export async function POST(request: NextRequest) {
 
         let candidateNames: string[];
         try {
-          candidateNames = await discoverCommunities(brandProfile, storeUrl);
+          candidateNames = await discoverCommunities(brandProfile);
         } catch (err) {
           emit({ type: "step", step: 3, status: "error", msg: `Discovery failed: ${err instanceof Error ? err.message : String(err)}` });
           emit({ type: "fatal", msg: "Could not discover relevant Reddit communities." });

--- a/src/app/building/page.tsx
+++ b/src/app/building/page.tsx
@@ -99,7 +99,7 @@ export default function BuildingPage() {
             </Reveal>
 
             <Reveal delay={700}>
-              <a href="/a16z" className="lr-btn-primary inline-block">
+              <a href="/launch" className="lr-btn-primary inline-block">
                 Try the product now!
               </a>
             </Reveal>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,17 +72,6 @@ export default function Home() {
                   </a>
                 </div>
               </FadeIn>
-              <FadeIn delay={1700} duration={1000}>
-                <p
-                  className="text-sm"
-                  style={{
-                    color: "#9ca3af",
-                    letterSpacing: "0.02em",
-                  }}
-                >
-                  Demo Workflow, beta sign-up in the end.
-                </p>
-              </FadeIn>
             </div>
           </div>
         </section>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -13,18 +13,18 @@ type Plan = {
 
 const PLANS: Plan[] = [
   {
-    name: "Solo",
-    price: "$49",
-    unit: "/mo",
+    name: "Monthly",
+    price: "$29",
+    unit: "/30 days",
     forWho: "Brand owners and solopreneurs",
-    desc: "The core tool. Signal detection.",
+    desc: "The full tool. Signal detection and AI-assisted drafting, billed monthly.",
   },
   {
-    name: "Community Manager",
-    price: "$99",
-    unit: "/mo",
-    forWho: "Teams managing brand voice",
-    desc: "Tool plus AI-assisted automations.",
+    name: "Quarterly",
+    price: "$79",
+    unit: "/90 days",
+    forWho: "Best value — three months up front",
+    desc: "Everything in Monthly for 90 days. Save versus paying month to month.",
   },
 ];
 
@@ -127,7 +127,7 @@ export default function PricingPage() {
                       {p.desc}
                     </p>
                     <a
-                      href="/a16z"
+                      href="/launch"
                       className="lr-btn-primary inline-block"
                       style={{ marginTop: "1.75rem", alignSelf: "flex-start" }}
                     >
@@ -176,10 +176,10 @@ export default function PricingPage() {
                     simulation & backtesting.
                   </p>
                   <a
-                    href="mailto:manthan@legitreach.com"
+                    href="mailto:direct@legitreach.com"
                     className="lr-btn-primary inline-block"
                   >
-                    Contact sales
+                    Contact us
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Last-minute changes for the Boston Tech Week demo.

- **Pricing → 3 plans.** Replaced the old $49/$99 tiers with **$29 / 30 days**, **$79 / 90 days**, and **Enterprise → Contact us** (`mailto:direct@legitreach.com`). Updated consistently in three places: the [pricing page](src/app/pricing/page.tsx), the in-terminal "Choose your plan" modal ([Terminal.jsx](public/launch/src/Terminal.jsx)), and the [pitch deck](public/pitch-deck.html).
- **Launch-flow routing.** "Try the product now" (building) and "Get started" (pricing) now point to `/launch`; the `/a16z` flow is no longer linked from anywhere. (Home's "Create now!" already pointed to `/launch`.)
- **Landing copy.** Removed "Demo Workflow, beta sign-up in the end." from the home hero.
- **Pitch deck mobile fix.** The deck now renders as a fixed 16:9 canvas scaled to fully fit any viewport — identical composition on phone and desktop, scroll between slides, pinch-zoom to read. Download PDF is now a fixed on-screen button, and print emits proper slide-sized (1280×720) pages.
- **Demo stability — magic-scan 500 fix.** Removed the `exa-js` import (the package wasn't installed and no `EXA_API_KEY` was ever configured, which crashed the API route). Community discovery now runs through the existing Gemini path, so the scan flow is one external dependency lighter and won't break live.
- **Tour UX.** Moved the terminal tour's next/skip buttons from bottom-right to top-right so they're visible on phones when a user lands on the terminal.

## Why

These are targeted fixes to make the product solid for a live demo: correct pricing everywhere, a single clean entry flow, a deck that's presentable on a phone, and a scan endpoint that no longer 500s.

## Reviewer notes

- The `/a16z` page files still exist but are now unlinked — left in place intentionally to avoid demo-day risk; can be deleted in a follow-up.
- The pitch deck (`public/pitch-deck.html`) and the launch flow (`public/launch/src/*.jsx`) are static/in-browser-Babel assets, not part of the Next build.

## Test plan

- [x] `magic-scan` endpoint streams SSE through brand-profile + discovery without a 500
- [x] Pricing shows $29/30 days, $79/90 days, Enterprise → `direct@legitreach.com`
- [x] Home "Create now!" and building "Try the product now" → `/launch`
- [x] Home no longer shows the "Demo Workflow…" line
- [x] Pitch deck: full slide fits viewport (verified contain-logic at desktop; deterministic on mobile), fixed PDF button
- [ ] Verify printed PDF page sizing in a real browser print dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)